### PR TITLE
Fix help text. Accounts can now be queried by credential id as well.

### DIFF
--- a/src/Concordium/Client/GRPC.hs
+++ b/src/Concordium/Client/GRPC.hs
@@ -195,7 +195,11 @@ getAccountList hash = withUnaryBlock (call @"getAccountList") hash (to processJS
 getInstances :: Text -> ClientMonad IO (Either String Value)
 getInstances hash = withUnaryBlock (call @"getInstances") hash (to processJSON)
 
-getAccountInfo :: (MonadIO m) => Text -> Text -> ClientMonad m (Either String Value)
+-- |Retrieve the account information from the chain.
+getAccountInfo :: (MonadIO m)
+               => Text -- ^ Account identifier, either address or credential registration id.
+               -> Text -- ^ Block hash
+               -> ClientMonad m (Either String Value)
 getAccountInfo account hash = withUnary (call @"getAccountInfo") msg (to processJSON)
   where msg = defMessage & CF.blockHash .~ hash & CF.address .~ account
 

--- a/src/Concordium/Client/LegacyCommands.hs
+++ b/src/Concordium/Client/LegacyCommands.hs
@@ -263,7 +263,7 @@ getAccountInfoCommand =
     "GetAccountInfo"
     (info
        (GetAccountInfo <$>
-        strArgument (metavar "ACCOUNT" <> help "Account to be queried about") <*>
+        strArgument (metavar "IDENTIFIER" <> help "Account address or credential id to be queried about.") <*>
         optional (strArgument (metavar "BLOCK-HASH" <> help "Hash of the block in which to do the query"))
        )
        (progDesc "Query the gRPC server for the information of an account."))


### PR DESCRIPTION
## Purpose

Accounts can now be queried either by address or by the registration id of a credential that is or was associated with the account. The change reflects this in the help text, the functionality was already supported by the client.

The nice commands will need to be updated later since it is more work that is not important at the moment (see #4 )

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
