### PR TITLE
Made possible to encrypt/decrypt baker keys

### DIFF
--- a/src/Concordium/Client/Runner.hs
+++ b/src/Concordium/Client/Runner.hs
@@ -1141,8 +1141,8 @@ bakerAddTransaction baseCfg txOpts f batcBakingStake batcRestakeEarnings confirm
   bakerKeysMaybeEncrypted <- handleReadFile BS.readFile f
   let pwdAction = askPassword "Enter password for decrypting baker keys: "
   (bakerKeys, wasEncrypted) <- Password.decodeMaybeEncrypted pwdAction bakerKeysMaybeEncrypted >>= \case
-         (Left err, _) -> logFatal [printf "error: %s" err]
-         (Right v, b) -> return (v, b)
+         Left err -> logFatal [printf "error: %s" err]
+         Right (v, b) -> return (v, b)
   
   let electionSignKey = bkElectionSignKey bakerKeys
       signatureSignKey = bkSigSignKey bakerKeys
@@ -2415,8 +2415,8 @@ bakerSetKeysTransaction baseCfg txOpts fp confirm = do
     bakerKeysMaybeEncrypted <- handleReadFile BS.readFile fp
     let pwdAction = askPassword "Enter password for decrypting baker keys: "
     (bsktcBakerKeys, wasEncrypted) <- Password.decodeMaybeEncrypted pwdAction bakerKeysMaybeEncrypted >>= \case
-         (Left err, _) -> logFatal [printf "error: %s" err]
-         (Right v, b) -> return (v, b)
+         Left err -> logFatal [printf "error: %s" err]
+         Right (v, b) -> return (v, b)
 
 
     let electionSignKey = bkElectionSignKey bsktcBakerKeys

--- a/src/Concordium/Client/Runner.hs
+++ b/src/Concordium/Client/Runner.hs
@@ -2236,7 +2236,12 @@ processBakerCmd action baseCfgDir verbose backend =
       pwd <- askPassword "Enter password for encryption of baker keys (leave blank for no encryption): "
       out <- case Password.getPassword pwd of
         "" -> return $ AE.encodePretty keys
-        _ -> AE.encodePretty <$> Password.encryptJSON Password.AES256 Password.PBKDF2SHA256 keys pwd
+        _ -> do 
+          pwd2 <- askPassword "Re-enter password for encryption of baker keys: "
+          if pwd == pwd2 then
+            AE.encodePretty <$> Password.encryptJSON Password.AES256 Password.PBKDF2SHA256 keys pwd
+          else 
+            logFatal ["The two passwords were not equal."]
       case outputFile of
         Nothing -> do
           -- TODO Store in config.

--- a/src/Concordium/Client/Runner.hs
+++ b/src/Concordium/Client/Runner.hs
@@ -1139,7 +1139,7 @@ bakerAddTransaction baseCfg txOpts f batcBakingStake batcRestakeEarnings confirm
   encSignData <- getAccountCfgFromTxOpts baseCfg txOpts
    
   bakerKeysMaybeEncrypted <- handleReadFile BS.readFile f
-  let pwdAction = askPassword ("Enter password for decrypting baker keys: ")
+  let pwdAction = askPassword "Enter password for decrypting baker keys: "
   (bakerKeys, wasEncrypted) <- Password.decodeMaybeEncrypted pwdAction bakerKeysMaybeEncrypted >>= \case
          (Left err, _) -> logFatal [printf "error: %s" err]
          (Right v, b) -> return (v, b)
@@ -2413,7 +2413,7 @@ bakerSetKeysTransaction baseCfg txOpts fp confirm = do
   when (isNothing airBaker) $ logFatal [printf "Account %s is not a baker, so cannot set its keys." (show senderAddress)]
   liftIO $ do
     bakerKeysMaybeEncrypted <- handleReadFile BS.readFile fp
-    let pwdAction = askPassword ("Enter password for decrypting baker keys:")
+    let pwdAction = askPassword "Enter password for decrypting baker keys: "
     (bsktcBakerKeys, wasEncrypted) <- Password.decodeMaybeEncrypted pwdAction bakerKeysMaybeEncrypted >>= \case
          (Left err, _) -> logFatal [printf "error: %s" err]
          (Right v, b) -> return (v, b)


### PR DESCRIPTION
## Purpose

The purpose of this PR is to make it possible to encrypt baker keys when generating them and decrypt them when adding them or setting them via `baker add` and `baker set-key`.

## Changes

It is now possible to optionally encrypt the baker keys and to decrypt them if they are encrypted. 

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [ ] I have documented my code, in particular the intent of the
      hard-to-understand areas.

