### PR TITLE
Limited expiry

### DIFF
--- a/concordium-client.cabal
+++ b/concordium-client.cabal
@@ -4,10 +4,10 @@ cabal-version: 2.0
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: d7cd14e31c4dfcd021cc0378c43ad0a06ce691d922bf2dd81f0e4424f5e14f91
+-- hash: e5d715662fd164d199288c52f2e6cf1291916ed3a98381ea50dbd8e4e8db1b57
 
 name:           concordium-client
-version:        0.6.0
+version:        0.7.0
 description:    Please see the README on GitHub at <https://github.com/Concordium/concordium-client#readme>
 homepage:       https://github.com/Concordium/concordium-client#readme
 bug-reports:    https://github.com/Concordium/concordium-client/issues

--- a/generator/Main.hs
+++ b/generator/Main.hs
@@ -118,6 +118,7 @@ main = do
                 ..
                 }
           let sign nonce () = do
+                -- set expiry for 1h from now so that the transaction will be accepted by the node.
                 ct <- utcTimeToTransactionTime <$> getCurrentTime
                 return (txRecepient nonce, NormalTransaction $ signTransaction keysList (txHeader (ct + 3600) nonce) (txBody nonce), ())
           go backend (logit txoptions) (tps txoptions) () sign (airNonce accInfo)

--- a/generator/Main.hs
+++ b/generator/Main.hs
@@ -110,14 +110,16 @@ main = do
                   Just addrs -> addrs !! (fromIntegral n `mod` length addrs)
                   Nothing -> selfAddress
           let txBody n = encodePayload (Transfer (txRecepient n) 1)
-          let txHeader nonce = TransactionHeader {
+          let txHeader thExpiry nonce = TransactionHeader {
                 thSender = selfAddress,
                 thNonce = nonce,
                 thEnergyAmount = 1500,
                 thPayloadSize = payloadSize (txBody nonce),
-                thExpiry = TransactionTime maxBound
+                ..
                 }
-          let sign nonce () = return (txRecepient nonce, NormalTransaction $ signTransaction keysList (txHeader nonce) (txBody nonce), ())
+          let sign nonce () = do
+                ct <- utcTimeToTransactionTime <$> getCurrentTime
+                return (txRecepient nonce, NormalTransaction $ signTransaction keysList (txHeader (ct + 3600) nonce) (txBody nonce), ())
           go backend (logit txoptions) (tps txoptions) () sign (airNonce accInfo)
         True -> do
           globalParameters <- withClient backend (getBestBlockHash >>= getParseCryptographicParameters) >>= \case
@@ -149,16 +151,17 @@ main = do
                     aggAmount = makeAggregatedDecryptedAmount encryptedAmount decryptedAmount 0
                 Just eatd <- makeEncryptedAmountTransferData globalParameters encryptionKey encryptionSecretKey aggAmount 0
                 return (encodePayload (EncryptedAmountTransfer address eatd), (eatdRemainingAmount eatd, decryptedAmount))
-          let txHeader nonce body = TransactionHeader {
+          let txHeader thExpiry nonce body = TransactionHeader {
                 thSender = selfAddress,
                 thNonce = nonce,
                 thEnergyAmount = encryptedTransferEnergyCost (payloadSize body) (length keysList),
                 thPayloadSize = payloadSize body,
-                thExpiry = TransactionTime maxBound
+                ..
                 }
           let sign nonce carry = do
+                ct <- utcTimeToTransactionTime <$> getCurrentTime
                 (body, newSelfAmount) <- txBody nonce carry
-                return (fst (txRecepient nonce), NormalTransaction $ signTransaction keysList (txHeader nonce body) body, newSelfAmount)
+                return (fst (txRecepient nonce), NormalTransaction $ signTransaction keysList (txHeader (ct + 3600) nonce body) body, newSelfAmount)
           go backend (logit txoptions) (tps txoptions) (ownAmount, plain) sign (airNonce accInfo)
 
   where accountKeysParser = AE.withObject "Account keys" $ \v -> do

--- a/package.yaml
+++ b/package.yaml
@@ -1,5 +1,5 @@
 name:                concordium-client
-version:             0.6.0
+version:             0.7.0
 github:              "Concordium/concordium-client"
 author:              "Concordium"
 maintainer:          "developers@concordium.com"


### PR DESCRIPTION
## Purpose

Limit expiry in the transaction generator and bump client & generator version.

This makes it possible to use the transaction generator with the current node version which limits transaction expiry.

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
