### PR TITLE
Output public parts of baker keys, optionally containing baker id.

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,6 +1,11 @@
 # Changelog for concordium-client
 
 ## Unreleased changes
+
+- baker generate-keys outputs public and private keys in separate files, and
+  optionally includes baker-id
+
+## 0.7.0
 - Add ContractName and ReceiveName to schema.
 - Add UInt128 and Int128 to schema type.
 - Add 'transaction register-data' command.

--- a/concordium-client.cabal
+++ b/concordium-client.cabal
@@ -4,10 +4,10 @@ cabal-version: 2.0
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: e5d715662fd164d199288c52f2e6cf1291916ed3a98381ea50dbd8e4e8db1b57
+-- hash: 1e3a320330daa596971b1c24efacf48381f5e6f18c9b6b610bb6bc4655fb9ba0
 
 name:           concordium-client
-version:        0.7.0
+version:        0.8.0
 description:    Please see the README on GitHub at <https://github.com/Concordium/concordium-client#readme>
 homepage:       https://github.com/Concordium/concordium-client#readme
 bug-reports:    https://github.com/Concordium/concordium-client/issues

--- a/package.yaml
+++ b/package.yaml
@@ -1,5 +1,5 @@
 name:                concordium-client
-version:             0.7.0
+version:             0.8.0
 github:              "Concordium/concordium-client"
 author:              "Concordium"
 maintainer:          "developers@concordium.com"

--- a/src/Concordium/Client/Cli.hs
+++ b/src/Concordium/Client/Cli.hs
@@ -487,25 +487,24 @@ instance AE.FromJSON BakerKeys where
 
 bakerKeysToPairs :: BakerKeys -> [Pair]
 bakerKeysToPairs v = [ "aggregationSignKey" .= bkAggrSignKey v
-                    , "aggregationVerifyKey" .= bkAggrVerifyKey v
-                    , "electionPrivateKey" .= bkElectionSignKey v
-                    , "electionVerifyKey" .= bkElectionVerifyKey v
-                    , "signatureSignKey" .= bkSigSignKey v
-                    , "signatureVerifyKey" .= bkSigVerifyKey v ]
+                     , "aggregationVerifyKey" .= bkAggrVerifyKey v
+                     , "electionPrivateKey" .= bkElectionSignKey v
+                     , "electionVerifyKey" .= bkElectionVerifyKey v
+                     , "signatureSignKey" .= bkSigSignKey v
+                     , "signatureVerifyKey" .= bkSigVerifyKey v ]
 
 instance AE.ToJSON BakerKeys where
   toJSON = object . bakerKeysToPairs
 
 -- Helper function for generating JSON containing only the public parts of the baker keys
 bakerPublicKeysToPairs :: BakerKeys -> Maybe BakerId -> [Pair]
-bakerPublicKeysToPairs v mbid = case mbid of
-  Nothing -> ["aggregationVerifyKey" .= bkAggrVerifyKey v
-                    , "electionVerifyKey" .= bkElectionVerifyKey v
-                    , "signatureVerifyKey" .= bkSigVerifyKey v ]
-  Just bid -> ["aggregationVerifyKey" .= bkAggrVerifyKey v
-                    , "electionVerifyKey" .= bkElectionVerifyKey v
-                    , "signatureVerifyKey" .= bkSigVerifyKey v 
-                    , "bakerId" .= bid ]
+bakerPublicKeysToPairs v mbid = 
+  let p = ["aggregationVerifyKey" .= bkAggrVerifyKey v
+         , "electionVerifyKey" .= bkElectionVerifyKey v
+         , "signatureVerifyKey" .= bkSigVerifyKey v ] 
+  in case mbid of
+    Nothing -> p
+    Just bid -> ("bakerId" .= bid) :p
 
 -- |Hardcoded network ID.
 defaultNetId :: Int

--- a/src/Concordium/Client/Cli.hs
+++ b/src/Concordium/Client/Cli.hs
@@ -496,6 +496,17 @@ bakerKeysToPairs v = [ "aggregationSignKey" .= bkAggrSignKey v
 instance AE.ToJSON BakerKeys where
   toJSON = object . bakerKeysToPairs
 
+-- Helper function for generating JSON containing only the public parts of the baker keys
+bakerPublicKeysToPairs :: BakerKeys -> Maybe BakerId -> [Pair]
+bakerPublicKeysToPairs v mbid = case mbid of
+  Nothing -> ["aggregationVerifyKey" .= bkAggrVerifyKey v
+                    , "electionVerifyKey" .= bkElectionVerifyKey v
+                    , "signatureVerifyKey" .= bkSigVerifyKey v ]
+  Just bid -> ["aggregationVerifyKey" .= bkAggrVerifyKey v
+                    , "electionVerifyKey" .= bkElectionVerifyKey v
+                    , "signatureVerifyKey" .= bkSigVerifyKey v 
+                    , "bakerId" .= bid ]
+
 -- |Hardcoded network ID.
 defaultNetId :: Int
 defaultNetId = 100

--- a/src/Concordium/Client/Commands.hs
+++ b/src/Concordium/Client/Commands.hs
@@ -1225,7 +1225,7 @@ bakerGenerateKeysCmd =
     (info
       (BakerGenerateKeys <$>
         optional (strArgument (metavar "FILE" <> help "Target file of generated credentials.")) <*>
-        optional (option auto (long "baker-id" <> metavar "BAKERID" <> help "Optionally provide the baker id.")))
+        optional (option auto (long "baker-id" <> metavar "BAKERID" <> help "Optionally provide the baker id to be written to FILE.pub together with the public baker keys.")))
       (progDescDoc $ docFromLines
         [ "Create baker credentials and write them to a file or stdout. Format:"
         , "    {"

--- a/src/Concordium/Client/Commands.hs
+++ b/src/Concordium/Client/Commands.hs
@@ -354,7 +354,8 @@ data BlockCmd
 
 data BakerCmd
   = BakerGenerateKeys
-    { bgkFile :: !(Maybe FilePath) }
+    { bgkFile :: !(Maybe FilePath)
+    , bgkBakerId :: !(Maybe BakerId) }
   | BakerAdd
     { baFile :: !FilePath
     , baTransactionOpts :: !(TransactionOpts (Maybe Energy))
@@ -1223,7 +1224,8 @@ bakerGenerateKeysCmd =
     "generate-keys"
     (info
       (BakerGenerateKeys <$>
-        optional (strArgument (metavar "FILE" <> help "Target file of generated credentials.")))
+        optional (strArgument (metavar "FILE" <> help "Target file of generated credentials.")) <*>
+        optional (option auto (long "baker-id" <> metavar "BAKERID" <> help "Optionally provide the baker id.")))
       (progDescDoc $ docFromLines
         [ "Create baker credentials and write them to a file or stdout. Format:"
         , "    {"

--- a/src/Concordium/Client/Commands.hs
+++ b/src/Concordium/Client/Commands.hs
@@ -1224,10 +1224,13 @@ bakerGenerateKeysCmd =
     "generate-keys"
     (info
       (BakerGenerateKeys <$>
-        optional (strArgument (metavar "FILE" <> help "Target file of generated credentials.")) <*>
-        optional (option auto (long "baker-id" <> metavar "BAKERID" <> help "Optionally provide the baker id to be written to FILE.pub together with the public baker keys.")))
+        optional (strArgument (metavar "FILE" <> help "File to write keys to.")) <*>
+        optional (option auto (long "baker-id" <> metavar "BAKERID" <> help "Optionally provide the baker id to be included with generated baker keys.")))
       (progDescDoc $ docFromLines
-        [ "Create baker credentials and write them to a file or stdout. Format:"
+        [ "Create baker credentials and write them to a file or stdout.",
+          "If the output file is specified secret keys are written to it,"
+        , " and public keys are written to the file with the same name but '.pub.json' extension."
+        , "Format:"
         , "    {"
         , "      \"signatureSignKey\": ...,"
         , "      \"signatureVerifyKey\": ...,"

--- a/src/Concordium/Client/Runner.hs
+++ b/src/Concordium/Client/Runner.hs
@@ -2258,7 +2258,7 @@ processBakerCmd action baseCfgDir verbose backend =
           logSuccess [ printf "keys written to file '%s'" f
                      , "DO NOT LOSE THIS FILE"
                      , printf "to add a baker to the chain using these keys, use 'concordium-client baker add %s'" f ]
-          logSuccess [ printf "public parts of keys written to file '%s.pub'" f]
+          logSuccess [ printf "public keys written to file '%s.pub'" f]
     BakerAdd bakerKeysFile txOpts initialStake autoRestake outputFile -> do
       baseCfg <- getBaseConfig baseCfgDir verbose
       when verbose $ do


### PR DESCRIPTION
## Purpose

The purpose is to let the `baker generate-keys` command additionally output the public parts of the baker keys, optionally containing the baker-id. 

## Changes

The `baker generate-keys` now additionally outputs the public parts of the baker keys, and if provided with a new `--baker-id` option, the output will contain this provided baker id. 

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.


