### PR TITLE
Minor bug fixes and improvements

### DIFF
--- a/src/Concordium/Client/Output.hs
+++ b/src/Concordium/Client/Output.hs
@@ -573,9 +573,10 @@ showRejectReason verbose = \case
   Types.OutOfEnergy ->
     "not enough energy"
   Types.RejectedInit{..} ->
-    [i|"contract init logic failed with code #{rejectReason}|]
+    [i|contract init logic failed with code #{rejectReason}|]
   Types.RejectedReceive{..} ->
-    [i|"contract #{receiveName} at #{showCompactPrettyJSON ContractAddress} failed with code #{rejectReason}|]
+    let (contractName, funcName) = Wasm.contractAndFunctionName receiveName
+    in [i|'#{funcName}' in '#{contractName}' at #{showCompactPrettyJSON contractAddress} failed with code #{rejectReason}|]
   Types.NonExistentRewardAccount a ->
     if verbose then
       printf "account '%s' does not exist (tried to set baker reward account)" (show a)

--- a/test/SimpleClientTests/ContractSpec.hs
+++ b/test/SimpleClientTests/ContractSpec.hs
@@ -228,6 +228,7 @@ printParameterSpec = describe "serialize JSON params to bytes and deserialize to
     fromToJSONFail (ReceiveName One) $ object [ "contract" .= AE.String "contrName"
                                                     , "func" .= AE.String "funcName"
                                                     , "extra" .= AE.String "extra"]
+    fromToJSONFail (ReceiveName One) $ object [ "contract" .= AE.String "contrName.withDot", "func" .= AE.String "funcName" ]
 
   where idx :: Word64
         idx = 42


### PR DESCRIPTION
## Purpose

1. Improves error messages for update failures:
   - **From:**`"contract ReceiveName {receiveName = "counter.receive"} at "ContractAddress" failed with code -2.`
   - **To:** `'receive' in 'counter' at {"index":4,"subindex":0} failed with code -2.`
2. Fixes incorrect parsing of `ReceiveName` when the 'contract' field contained a dot:

Example:
```json
{"contract": "contrName.withDot", "func": "funcName"}
```
would be parsed as
```json
{"contract": "contrName", "func": "withDot.funcName"}
```

Now, the validity of the contract name is checked on its own, and the example produces an error.

## Changes

For 1: Update error messages.
For 2: 
   - Add a check for the validity of the 'contract' field on its own
   - Add regression test.

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.