### PR TITLE
Fix JSON parsing of baker id.

### DIFF
--- a/src/Concordium/Client/Cli.hs
+++ b/src/Concordium/Client/Cli.hs
@@ -486,7 +486,7 @@ instance AE.FromJSON BakerKeys where
     bkElectionVerifyKey <- v .: "electionVerifyKey"
     bkSigSignKey <- v .: "signatureSignKey"
     bkSigVerifyKey <- v .: "signatureVerifyKey"
-    bkBakerId <- v .: "bakerId"
+    bkBakerId <- v .:? "bakerId"
     return BakerKeys {..}
 
 bakerKeysToPairs :: BakerKeys -> [Pair]


### PR DESCRIPTION
## Purpose

To fix how the baker id is read when parsing the baker keys as JSON. 

## Changes

".:" was changed to ".:?". 

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.

