### PR TITLE
Fix typo in command description.

### DIFF
--- a/src/Concordium/Client/LegacyCommands.hs
+++ b/src/Concordium/Client/LegacyCommands.hs
@@ -383,7 +383,7 @@ unbanNodeCommand =
        (UnbanNode <$>
         optional (strOption (long "node-id" <> metavar "NODE-ID" <> help "ID of the node to be unbanned")) <*>
         optional (strOption (long "ip" <> metavar "NODE-IP" <> help "IP of the node to be banned")))
-       (progDesc "Unban a node. The node to ban can either be supplied via a node-id or via an IP."))
+       (progDesc "Unban a node. The node to unban can either be supplied via a node-id or via an IP."))
 
 joinNetworkCommand :: Mod CommandFields LegacyCmd
 joinNetworkCommand =


### PR DESCRIPTION
Closes #40.

## Purpose

Fix typo in command help description.

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.

