### PR TITLE
Transaction memos

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -3,7 +3,7 @@
 ## Unreleased changes
 - The `account show` command can receive a credential registration ID instead of a name or address.
 
-## 1.1
+## 1.1.0
 - support sending the three new transaction types, i.e. TransferWithMemo, EncryptedTransferWithMemo
   and TransferWithScheduleAndMemo
 - show transfer memo in transaction status

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -9,6 +9,7 @@
 - show transfer memo in transaction status
 - show protocolVersion, genesisIndex, currentEraGenesisBlock and currentEraGenesisTime in 
   consensus status
+- this version is only compatible with node version 1.1.0 and later.
 
 ## 1.0.1
 

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -3,6 +3,13 @@
 ## Unreleased changes
 - The `account show` command can receive a credential registration ID instead of a name or address.
 
+## 1.1
+- support sending the three new transaction types, i.e. TransferWithMemo, EncryptedTransferWithMemo
+  and TransferWithScheduleAndMemo
+- show transfer memo in transaction status
+- show protocolVersion, genesisIndex, currentEraGenesisBlock and currentEraGenesisTime in 
+  consensus status
+
 ## 1.0.1
 
 - support the new mobile wallet export format. This breaks compatibility with

--- a/concordium-client.cabal
+++ b/concordium-client.cabal
@@ -5,7 +5,7 @@ cabal-version: 2.0
 -- see: https://github.com/sol/hpack
 
 name:           concordium-client
-version:        1.1
+version:        1.1.0
 description:    Please see the README on GitHub at <https://github.com/Concordium/concordium-client#readme>
 homepage:       https://github.com/Concordium/concordium-client#readme
 bug-reports:    https://github.com/Concordium/concordium-client/issues

--- a/concordium-client.cabal
+++ b/concordium-client.cabal
@@ -1,10 +1,10 @@
 cabal-version: 2.0
 
--- This file has been generated from package.yaml by hpack version 0.34.4.
+-- This file has been generated from package.yaml by hpack version 0.33.0.
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: e81ac8f8ccfb533313a49381417d77b6ea979e40b403d3968c98c39aac04a48f
+-- hash: ac4ef84a42a671516a8c239ff0ce630e628b542f933d0454683b63cc5ddb0758
 
 name:           concordium-client
 version:        1.0.1
@@ -69,14 +69,7 @@ library
       Proto.ConcordiumP2pRpc Proto.ConcordiumP2pRpc_Fields
   hs-source-dirs:
       src
-  default-extensions:
-      OverloadedStrings
-      RecordWildCards
-      GeneralizedNewtypeDeriving
-      ScopedTypeVariables
-      FlexibleContexts
-      LambdaCase
-      TupleSections
+  default-extensions: OverloadedStrings RecordWildCards GeneralizedNewtypeDeriving ScopedTypeVariables FlexibleContexts LambdaCase TupleSections
   ghc-options: -Wall -Wcompat -Werror=missing-fields -Wredundant-constraints -O
   build-depends:
       aeson
@@ -89,6 +82,8 @@ library
     , base16-bytestring
     , base64-bytestring
     , bytestring
+    , cborg
+    , cborg-json
     , cereal
     , concordium-base
     , concurrent-extra >=0.7
@@ -126,14 +121,7 @@ executable concordium-client
       Paths_concordium_client
   hs-source-dirs:
       app
-  default-extensions:
-      OverloadedStrings
-      RecordWildCards
-      GeneralizedNewtypeDeriving
-      ScopedTypeVariables
-      FlexibleContexts
-      LambdaCase
-      TupleSections
+  default-extensions: OverloadedStrings RecordWildCards GeneralizedNewtypeDeriving ScopedTypeVariables FlexibleContexts LambdaCase TupleSections
   ghc-options: -Wall -Wcompat -Werror=missing-fields -Wredundant-constraints -O
   build-depends:
       base
@@ -154,14 +142,7 @@ executable middleware
       Paths_concordium_client
   hs-source-dirs:
       middleware
-  default-extensions:
-      OverloadedStrings
-      RecordWildCards
-      GeneralizedNewtypeDeriving
-      ScopedTypeVariables
-      FlexibleContexts
-      LambdaCase
-      TupleSections
+  default-extensions: OverloadedStrings RecordWildCards GeneralizedNewtypeDeriving ScopedTypeVariables FlexibleContexts LambdaCase TupleSections
   ghc-options: -Wall -threaded
   build-depends:
       aeson
@@ -204,14 +185,7 @@ executable tx-generator
       Paths_concordium_client
   hs-source-dirs:
       generator
-  default-extensions:
-      OverloadedStrings
-      RecordWildCards
-      GeneralizedNewtypeDeriving
-      ScopedTypeVariables
-      FlexibleContexts
-      LambdaCase
-      TupleSections
+  default-extensions: OverloadedStrings RecordWildCards GeneralizedNewtypeDeriving ScopedTypeVariables FlexibleContexts LambdaCase TupleSections
   ghc-options: -Wall -Wcompat -Werror=missing-fields -Wredundant-constraints -O -threaded
   build-depends:
       aeson
@@ -246,14 +220,7 @@ test-suite concordium-client-test
       Paths_concordium_client
   hs-source-dirs:
       test
-  default-extensions:
-      OverloadedStrings
-      RecordWildCards
-      GeneralizedNewtypeDeriving
-      ScopedTypeVariables
-      FlexibleContexts
-      LambdaCase
-      TupleSections
+  default-extensions: OverloadedStrings RecordWildCards GeneralizedNewtypeDeriving ScopedTypeVariables FlexibleContexts LambdaCase TupleSections
   ghc-options: -Wall -Wcompat -Werror=missing-fields -Wredundant-constraints -O
   build-depends:
       HUnit >=1.6

--- a/concordium-client.cabal
+++ b/concordium-client.cabal
@@ -1,13 +1,11 @@
 cabal-version: 2.0
 
--- This file has been generated from package.yaml by hpack version 0.33.0.
+-- This file has been generated from package.yaml by hpack version 0.34.4.
 --
 -- see: https://github.com/sol/hpack
---
--- hash: ac4ef84a42a671516a8c239ff0ce630e628b542f933d0454683b63cc5ddb0758
 
 name:           concordium-client
-version:        1.0.1
+version:        1.1
 description:    Please see the README on GitHub at <https://github.com/Concordium/concordium-client#readme>
 homepage:       https://github.com/Concordium/concordium-client#readme
 bug-reports:    https://github.com/Concordium/concordium-client/issues
@@ -69,7 +67,14 @@ library
       Proto.ConcordiumP2pRpc Proto.ConcordiumP2pRpc_Fields
   hs-source-dirs:
       src
-  default-extensions: OverloadedStrings RecordWildCards GeneralizedNewtypeDeriving ScopedTypeVariables FlexibleContexts LambdaCase TupleSections
+  default-extensions:
+      OverloadedStrings
+      RecordWildCards
+      GeneralizedNewtypeDeriving
+      ScopedTypeVariables
+      FlexibleContexts
+      LambdaCase
+      TupleSections
   ghc-options: -Wall -Wcompat -Werror=missing-fields -Wredundant-constraints -O
   build-depends:
       aeson
@@ -121,7 +126,14 @@ executable concordium-client
       Paths_concordium_client
   hs-source-dirs:
       app
-  default-extensions: OverloadedStrings RecordWildCards GeneralizedNewtypeDeriving ScopedTypeVariables FlexibleContexts LambdaCase TupleSections
+  default-extensions:
+      OverloadedStrings
+      RecordWildCards
+      GeneralizedNewtypeDeriving
+      ScopedTypeVariables
+      FlexibleContexts
+      LambdaCase
+      TupleSections
   ghc-options: -Wall -Wcompat -Werror=missing-fields -Wredundant-constraints -O
   build-depends:
       base
@@ -142,7 +154,14 @@ executable middleware
       Paths_concordium_client
   hs-source-dirs:
       middleware
-  default-extensions: OverloadedStrings RecordWildCards GeneralizedNewtypeDeriving ScopedTypeVariables FlexibleContexts LambdaCase TupleSections
+  default-extensions:
+      OverloadedStrings
+      RecordWildCards
+      GeneralizedNewtypeDeriving
+      ScopedTypeVariables
+      FlexibleContexts
+      LambdaCase
+      TupleSections
   ghc-options: -Wall -threaded
   build-depends:
       aeson
@@ -185,7 +204,14 @@ executable tx-generator
       Paths_concordium_client
   hs-source-dirs:
       generator
-  default-extensions: OverloadedStrings RecordWildCards GeneralizedNewtypeDeriving ScopedTypeVariables FlexibleContexts LambdaCase TupleSections
+  default-extensions:
+      OverloadedStrings
+      RecordWildCards
+      GeneralizedNewtypeDeriving
+      ScopedTypeVariables
+      FlexibleContexts
+      LambdaCase
+      TupleSections
   ghc-options: -Wall -Wcompat -Werror=missing-fields -Wredundant-constraints -O -threaded
   build-depends:
       aeson
@@ -220,7 +246,14 @@ test-suite concordium-client-test
       Paths_concordium_client
   hs-source-dirs:
       test
-  default-extensions: OverloadedStrings RecordWildCards GeneralizedNewtypeDeriving ScopedTypeVariables FlexibleContexts LambdaCase TupleSections
+  default-extensions:
+      OverloadedStrings
+      RecordWildCards
+      GeneralizedNewtypeDeriving
+      ScopedTypeVariables
+      FlexibleContexts
+      LambdaCase
+      TupleSections
   ghc-options: -Wall -Wcompat -Werror=missing-fields -Wredundant-constraints -O
   build-depends:
       HUnit >=1.6

--- a/package.yaml
+++ b/package.yaml
@@ -69,6 +69,8 @@ library:
     - base64-bytestring
     - bytestring
     - cereal
+    - cborg
+    - cborg-json
     - concordium-base
     - containers
     - cryptonite

--- a/package.yaml
+++ b/package.yaml
@@ -1,5 +1,5 @@
 name:                concordium-client
-version:             1.1
+version:             1.1.0
 github:              "Concordium/concordium-client"
 author:              "Concordium"
 maintainer:          "developers@concordium.com"

--- a/package.yaml
+++ b/package.yaml
@@ -1,5 +1,5 @@
 name:                concordium-client
-version:             1.0.1
+version:             1.1
 github:              "Concordium/concordium-client"
 author:              "Concordium"
 maintainer:          "developers@concordium.com"

--- a/src/Concordium/Client/Cli.hs
+++ b/src/Concordium/Client/Cli.hs
@@ -361,7 +361,10 @@ data ConsensusStatusResult = ConsensusStatusResult
   , csrLastFinalizedTime :: Maybe UTCTime
   , csrFinalizationPeriodEMA :: Maybe Double
   , csrFinalizationPeriodEMSD :: Maybe Double
-  , csrProtocolVersion :: ProtocolVersion }
+  , csrProtocolVersion :: ProtocolVersion
+  , csrGenesisIndex :: GenesisIndex
+  , csrCurrentEraGenesisBlock :: !BlockHash
+  , csrCurrentEraGenesisTime  :: !UTCTime }
 
 instance AE.FromJSON ConsensusStatusResult where
   parseJSON = withObject "Consensus state" $ \v -> do
@@ -392,6 +395,9 @@ instance AE.FromJSON ConsensusStatusResult where
     csrFinalizationPeriodEMA <- v .: "finalizationPeriodEMA"
     csrFinalizationPeriodEMSD <- v .: "finalizationPeriodEMSD"
     csrProtocolVersion <- v .:? "protocolVersion" .!= P1
+    csrGenesisIndex <- v .:? "genesisIndex" .!= 0
+    csrCurrentEraGenesisBlock <- v .:? "currentEraGenesisBlock" .!= csrGenesisBlock
+    csrCurrentEraGenesisTime <- v .:? "currentEraGenesisTime" .!= csrGenesisTime
     return $ ConsensusStatusResult {..}
 
 data BirkParametersResult = BirkParametersResult

--- a/src/Concordium/Client/Cli.hs
+++ b/src/Concordium/Client/Cli.hs
@@ -366,20 +366,6 @@ data ConsensusStatusResult = ConsensusStatusResult
   , csrCurrentEraGenesisBlock :: !BlockHash
   , csrCurrentEraGenesisTime  :: !UTCTime }
 
--- The JSON fields protocolVersion, genesisIndex, currentEraGenesisBlock and currentEraGenesisTime
--- are introduced in protocol version 2, so if these are not returned by the node, we assume¨
--- that the node is running in protocol version 1. We therefore use the default values
--- * P1 for protocolVersion 
--- * 0 for genesisIndex since the first protocol update to increase the genesisIndex is
---   assumed to change the protocol version to 2, and thus we can assume that the
---   genesisIndex is 0, if it isn't returned by the node.
--- * csrGenesisBlock for currentEraGenesisBlock since the first protocol update
---   changes the protocol version to 2, meaning that if currentEraGenesisBlock
---   is not returned by the node, then the current genesis block is the very
---   first genesis block (since no regenesis would have happened yet)
--- * csrGenesisTime for currentEraGenesisTime since (again) no regenesis 
---   would have happened if currentEraGenesisTime is not returned by the node.
-
 instance AE.FromJSON ConsensusStatusResult where
   parseJSON = withObject "Consensus state" $ \v -> do
     csrBestBlock <- v .: "bestBlock"
@@ -408,10 +394,10 @@ instance AE.FromJSON ConsensusStatusResult where
     csrLastFinalizedTime <- v .: "lastFinalizedTime"
     csrFinalizationPeriodEMA <- v .: "finalizationPeriodEMA"
     csrFinalizationPeriodEMSD <- v .: "finalizationPeriodEMSD"
-    csrProtocolVersion <- v .:? "protocolVersion" .!= P1
-    csrGenesisIndex <- v .:? "genesisIndex" .!= 0
-    csrCurrentEraGenesisBlock <- v .:? "currentEraGenesisBlock" .!= csrGenesisBlock
-    csrCurrentEraGenesisTime <- v .:? "currentEraGenesisTime" .!= csrGenesisTime
+    csrProtocolVersion <- v .: "protocolVersion"
+    csrGenesisIndex <- v .: "genesisIndex"
+    csrCurrentEraGenesisBlock <- v .: "currentEraGenesisBlock"
+    csrCurrentEraGenesisTime <- v .: "currentEraGenesisTime"
     return $ ConsensusStatusResult {..}
 
 data BirkParametersResult = BirkParametersResult

--- a/src/Concordium/Client/Cli.hs
+++ b/src/Concordium/Client/Cli.hs
@@ -360,7 +360,8 @@ data ConsensusStatusResult = ConsensusStatusResult
   , csrFinalizationCount :: Int
   , csrLastFinalizedTime :: Maybe UTCTime
   , csrFinalizationPeriodEMA :: Maybe Double
-  , csrFinalizationPeriodEMSD :: Maybe Double }
+  , csrFinalizationPeriodEMSD :: Maybe Double
+  , csrProtocolVersion :: ProtocolVersion }
 
 instance AE.FromJSON ConsensusStatusResult where
   parseJSON = withObject "Consensus state" $ \v -> do
@@ -390,6 +391,7 @@ instance AE.FromJSON ConsensusStatusResult where
     csrLastFinalizedTime <- v .: "lastFinalizedTime"
     csrFinalizationPeriodEMA <- v .: "finalizationPeriodEMA"
     csrFinalizationPeriodEMSD <- v .: "finalizationPeriodEMSD"
+    csrProtocolVersion <- v .:? "protocolVersion" .!= P1
     return $ ConsensusStatusResult {..}
 
 data BirkParametersResult = BirkParametersResult

--- a/src/Concordium/Client/Cli.hs
+++ b/src/Concordium/Client/Cli.hs
@@ -366,6 +366,20 @@ data ConsensusStatusResult = ConsensusStatusResult
   , csrCurrentEraGenesisBlock :: !BlockHash
   , csrCurrentEraGenesisTime  :: !UTCTime }
 
+-- The JSON fields protocolVersion, genesisIndex, currentEraGenesisBlock and currentEraGenesisTime
+-- are introduced in protocol version 2, so if these are not returned by the node, we assume¨
+-- that the node is running in protocol version 1. We therefore use the default values
+-- * P1 for protocolVersion 
+-- * 0 for genesisIndex since the first protocol update to increase the genesisIndex is
+--   assumed to change the protocol version to 2, and thus we can assume that the
+--   genesisIndex is 0, if it isn't returned by the node.
+-- * csrGenesisBlock for currentEraGenesisBlock since the first protocol update
+--   changes the protocol version to 2, meaning that if currentEraGenesisBlock
+--   is not returned by the node, then the current genesis block is the very
+--   first genesis block (since no regenesis would have happened yet)
+-- * csrGenesisTime for currentEraGenesisTime since (again) no regenesis 
+--   would have happened if currentEraGenesisTime is not returned by the node.
+
 instance AE.FromJSON ConsensusStatusResult where
   parseJSON = withObject "Consensus state" $ \v -> do
     csrBestBlock <- v .: "bestBlock"

--- a/src/Concordium/Client/Commands.hs
+++ b/src/Concordium/Client/Commands.hs
@@ -26,7 +26,7 @@ module Concordium.Client.Commands
 
 import Data.Text hiding (map, unlines)
 import Data.Version (showVersion)
-import Data.Word (Word64, Word8)
+import Data.Word (Word64)
 import Data.Time.Format.ISO8601
 import Network.HTTP2.Client
 import Options.Applicative

--- a/src/Concordium/Client/Output.hs
+++ b/src/Concordium/Client/Output.hs
@@ -40,9 +40,7 @@ import Lens.Micro.Platform
 import Text.Printf
 import Codec.CBOR.Read
 import Codec.CBOR.JSON
-import qualified Data.ByteString.Lazy as BSL
-import qualified Data.Aeson as AE
-import System.Directory.Internal.Prelude (fromMaybe)
+-- import System.Directory.Internal.Prelude (fromMaybe)
 
 -- PRINTER
 

--- a/src/Concordium/Client/Output.hs
+++ b/src/Concordium/Client/Output.hs
@@ -40,7 +40,6 @@ import Lens.Micro.Platform
 import Text.Printf
 import Codec.CBOR.Read
 import Codec.CBOR.JSON
--- import System.Directory.Internal.Prelude (fromMaybe)
 
 -- PRINTER
 

--- a/src/Concordium/Client/Output.hs
+++ b/src/Concordium/Client/Output.hs
@@ -42,6 +42,7 @@ import Codec.CBOR.Read
 import Codec.CBOR.JSON
 import qualified Data.ByteString.Lazy as BSL
 import qualified Data.Aeson as AE
+import System.Directory.Internal.Prelude (fromMaybe)
 
 -- PRINTER
 
@@ -658,7 +659,8 @@ printConsensusStatus r =
        , printf "Transactions per block:      %s" (showEm (printf "%8.3f" $ csrTransactionsPerBlockEMA r) (printf "%8.3f" $ csrTransactionsPerBlockEMSD r))
        , printf "Finalization count:          %s" (show $ csrFinalizationCount r)
        , printf "Last finalized time:         %s" (showMaybeUTC $ csrLastFinalizedTime r)
-       , printf "Finalization period:         %s" (showMaybeEmSeconds (csrFinalizationPeriodEMA r) (csrFinalizationPeriodEMSD r)) ]
+       , printf "Finalization period:         %s" (showMaybeEmSeconds (csrFinalizationPeriodEMA r) (csrFinalizationPeriodEMSD r))
+       , printf "Protocol version:            %s" (show $ csrProtocolVersion r) ]
 
 printBirkParameters :: Bool -> BirkParametersResult -> Map.Map IDTypes.AccountAddress Text -> Printer
 printBirkParameters includeBakers r addrmap = do

--- a/test/SimpleClientTests/ConsensusSpec.hs
+++ b/test/SimpleClientTests/ConsensusSpec.hs
@@ -40,7 +40,11 @@ consensusStatusSpec = describe "status" $ do
     , "Transactions per block:         0.110 (EMA),   12.135 (EMSD)"
     , "Finalization count:          14"
     , "Last finalized time:         Sat, 24 Jan 1970 03:33:20 UTC"
-    , "Finalization period:         100000 ms (EMA), 200000 ms (EMSD)" ]
+    , "Finalization period:         100000 ms (EMA), 200000 ms (EMSD)"
+    , "Protocol version:            P1"
+    , "Genesis index:               0"
+    , "Current era genesis block:   0f71eeca9f0a497dc4427cab0544f2bcb820b328ad97be29181e212edea708fd"
+    , "Current era genesis time:    1970-01-12 13:46:40 UTC" ]
 
   specify "optional fields absent" $ p exampleStatusWithoutOptionalFields `shouldBe`
     [ "Best block:                  0a5d64f644461d95315a781475b83f723f74d1c21542bd4f3e234d6173374389"
@@ -62,7 +66,11 @@ consensusStatusSpec = describe "status" $ do
     , "Transactions per block:         0.110 (EMA),   12.130 (EMSD)"
     , "Finalization count:          14"
     , "Last finalized time:         none"
-    , "Finalization period:         none" ]
+    , "Finalization period:         none" 
+    , "Protocol version:            P1"
+    , "Genesis index:               0"
+    , "Current era genesis block:   0f71eeca9f0a497dc4427cab0544f2bcb820b328ad97be29181e212edea708fd"
+    , "Current era genesis time:    1970-01-12 13:46:40 UTC" ]
   where p = execWriter . printConsensusStatus
 
 consensusShowParametersSpec :: Spec
@@ -124,7 +132,11 @@ exampleStatusWithOptionalFields =
   , csrFinalizationPeriodEMSD = Just 200
   , csrGenesisTime = exampleTime1
   , csrSlotDuration = 100000
-  , csrEpochDuration = 100000 }
+  , csrEpochDuration = 100000
+  , csrProtocolVersion = P1
+  , csrGenesisIndex = 0
+  , csrCurrentEraGenesisBlock = exampleBlockHash2
+  , csrCurrentEraGenesisTime = exampleTime1 }
 
 exampleStatusWithoutOptionalFields :: ConsensusStatusResult
 exampleStatusWithoutOptionalFields =
@@ -154,7 +166,11 @@ exampleStatusWithoutOptionalFields =
   , csrFinalizationPeriodEMSD = Nothing
   , csrGenesisTime = exampleTime1
   , csrSlotDuration = 100000
-  , csrEpochDuration = 100000 }
+  , csrEpochDuration = 100000
+  , csrProtocolVersion = P1
+  , csrGenesisIndex = 0
+  , csrCurrentEraGenesisBlock = exampleBlockHash2
+  , csrCurrentEraGenesisTime = exampleTime1 }
 
 exampleBirkParameters :: BirkParametersResult
 exampleBirkParameters =


### PR DESCRIPTION
## Purpose

To be able to send transactions with memos via concordium-client, and to warn the user when trying to send a transaction with a memo if protocol version is 1. 

- Closes #52
- Closes #53 

## Changes

The commands `send-gtu`, `send-gtu-encrypted` and `send-gtu-scheduled` have been extended with two memo flags:
- `--memo` for providing a memo as a string (which will be CBOR encoded on chain)
- `--memo-json` for providing a memo as json from a file (the json will be CBOR encoded on chain)
- `--memo-raw` for providing a memo as raw bytes from a file (the raw bytes will go on chain and thus **does not** necessarily  represent an CBOR encoding of anything)

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [x] (If necessary) I have updated the CHANGELOG.

