### PR TITLE
Warn when wasm module is too big, and when staking more than 95% of amount on account when adding a baker

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -2,14 +2,15 @@
 
 ## Unreleased changes
 - The `account show` command can receive a credential registration ID instead of a name or address.
-
-## 1.1.0
 - support sending the three new transaction types, i.e. TransferWithMemo, EncryptedTransferWithMemo
   and TransferWithScheduleAndMemo
 - show transfer memo in transaction status
 - show protocolVersion, genesisIndex, currentEraGenesisBlock and currentEraGenesisTime in 
   consensus status
 - this version is only compatible with node version 1.1.0 and later.
+- warn the user when trying to deploy a wasm module of size > 65536 bytes
+- warn the user when adding a baker staking more than 95% of the amount on the account
+- correct printing of cooldown time in `account show`
 
 ## 1.0.1
 

--- a/src/Concordium/Client/Runner.hs
+++ b/src/Concordium/Client/Runner.hs
@@ -1558,10 +1558,10 @@ processAccountCmd action baseCfgDir verbose backend =
           else return Nothing
         cs <- getFromJson =<< getConsensusStatus
         case encKey of
-          Nothing -> return (accInfo, na, Nothing, \e ->  addUTCTime (fromRational ((toInteger e * toInteger (csrEpochDuration cs)) % 1000)) (csrGenesisTime cs))
+          Nothing -> return (accInfo, na, Nothing, \e ->  addUTCTime (fromRational ((toInteger e * toInteger (csrEpochDuration cs)) % 1000)) (csrCurrentEraGenesisTime cs))
           Just k -> do
             gc <- logFatalOnError =<< getParseCryptographicParameters bbh
-            return (accInfo, na, Just (k, gc), \e ->  addUTCTime (fromRational ((toInteger e * toInteger (csrEpochDuration cs)) % 1000)) (csrGenesisTime cs))
+            return (accInfo, na, Just (k, gc), \e ->  addUTCTime (fromRational ((toInteger e * toInteger (csrEpochDuration cs)) % 1000)) (csrCurrentEraGenesisTime cs))
 
       runPrinter $ printAccountInfo f na accInfo verbose (showEncrypted || showDecrypted) dec
 
@@ -2369,21 +2369,25 @@ processBakerCmd action baseCfgDir verbose backend =
         putStrLn ""
 
       withClient backend $ do
-         let senderAddr = naAddr . esdAddress . tcEncryptedSigningData $ txCfg
-         AccountInfoResult{..} <- getAccountInfoOrDie senderAddr
-         energyrate <- getNrgGtuRate
-         let gtuTransactionPrice = Types.computeCost energyrate (tcEnergy txCfg) 
-         case airBaker of
-           Just AccountInfoBakerResult{..} -> logFatal [[i|Account is already a baker with ID #{aibiIdentity abirAccountBakerInfo}.|]]
-           Nothing -> do
-             if airAmount - gtuTransactionPrice < initialStake
-             then do
-               logError [[i|Account balance (#{showGtu airAmount}) minus the cost of the transaction (#{showGtu gtuTransactionPrice}) is lower than the amount requested to be staked (#{showGtu initialStake}).|]]
-               confirmed <- askConfirmation $ Just "This transaction will most likely be rejected by the chain, do you wish to send it anyway"
-               unless confirmed exitTransactionCancelled
-               sendAndMaybeOutputCredentials bakerKeys wasEncrypted bakerKeysFile outputFile txCfg pl intOpts
-             else do
-               sendAndMaybeOutputCredentials bakerKeys wasEncrypted bakerKeysFile outputFile txCfg pl intOpts
+        let senderAddr = naAddr . esdAddress . tcEncryptedSigningData $ txCfg
+        AccountInfoResult{..} <- getAccountInfoOrDie senderAddr
+        energyrate <- getNrgGtuRate
+        let gtuTransactionPrice = Types.computeCost energyrate (tcEnergy txCfg) 
+        case airBaker of
+          Just AccountInfoBakerResult{..} -> logFatal [[i|Account is already a baker with ID #{aibiIdentity abirAccountBakerInfo}.|]]
+          Nothing -> do
+            let cannotAfford = airAmount - gtuTransactionPrice < initialStake
+            when cannotAfford $ do
+              logWarn [[i|Account balance (#{showGtu airAmount}) minus the cost of the transaction (#{showGtu gtuTransactionPrice}) is lower than the amount requested to be staked (#{showGtu initialStake}).|]]
+              confirmed <- askConfirmation $ Just "This transaction will most likely be rejected by the chain, do you wish to send it anyway"
+              unless confirmed exitTransactionCancelled
+            -- Check if staked amount is greater than 95% of total GTU on the account, and warn user if so
+            when ((initialStake * 100) > (airAmount * 95) && not cannotAfford) $ do
+              logWarn ["You are attempting to stake >95% of your total GTU on this account. Staked GTU is not available for spending."]
+              logWarn ["Be aware that updating or stopping your baker in the future will require some amount of non-staked GTU to pay for the transactions to do so."]
+              confirmed <- askConfirmation $ Just "Confirm that you wish to stake this much GTU"
+              unless confirmed exitTransactionCancelled
+            sendAndMaybeOutputCredentials bakerKeys wasEncrypted bakerKeysFile outputFile txCfg pl intOpts
         where
           -- General function to fetch NrgGtu rate
           -- This functionality is going to be more generally used in an upcoming branch adding GTU prices to NRG printouts across the client.


### PR DESCRIPTION
## Purpose

* To warn the user when trying to deploy a wasm module of size > 65536 bytes. Closes #51 .
* To warn the user when adding a baker staking more than 95% of the amount on the account. Closes #7 .

## Changes

* The above mentioned warnings have been introduced.
* A bug in the display of cooldown period when doing `concordium-client account show ...` was found and corrected.

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [x] (If necessary) I have updated the CHANGELOG.
