### PR TITLE
Show raw state if schema type not found for state

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,6 +1,7 @@
 # Changelog for concordium-client
 
 ## Unreleased changes
+- show smart contract state as raw bytes, if schema is provided but doesn't include the state type.
 
 ## 1.1.0
 - The `account show` command can receive a credential registration ID instead of a name or address.

--- a/package.yaml
+++ b/package.yaml
@@ -1,5 +1,5 @@
 name:                concordium-client
-version:             1.1.0
+version:             1.1.1
 github:              "Concordium/concordium-client"
 author:              "Concordium"
 maintainer:          "developers@concordium.com"

--- a/src/Concordium/Client/Output.hs
+++ b/src/Concordium/Client/Output.hs
@@ -30,7 +30,6 @@ import qualified Data.ByteString.Short as BSS
 import qualified Data.ByteString.Lazy as BSL
 import Data.Functor
 import qualified Data.Map.Strict as Map
-import qualified Data.HashMap.Strict as HM
 import Data.List (foldl', intercalate, nub)
 import Data.Maybe
 import Data.String.Interpolate (i)

--- a/src/Concordium/Client/Types/Contract/Info.hs
+++ b/src/Concordium/Client/Types/Contract/Info.hs
@@ -11,7 +11,7 @@ import qualified Concordium.Client.Types.Contract.Schema as CS
 import qualified Concordium.Client.Types.Contract.Parameter as CP
 import qualified Concordium.Wasm as Wasm
 
-import Data.Aeson ((.=), (.:))
+import Data.Aeson ((.:))
 import qualified Data.Aeson as AE
 import Data.ByteString (ByteString)
 import qualified Data.ByteString as BS

--- a/src/Concordium/Client/Types/Contract/Info.hs
+++ b/src/Concordium/Client/Types/Contract/Info.hs
@@ -71,7 +71,11 @@ data ContractState =
     WithSchema
     {
       wsModuleSchema :: !CS.ModuleSchema, -- ^ The module schema
-      wsValue :: !(Maybe AE.Value), -- ^ The decoded contract state, if schema type found for the state.
+      wsValue :: !(Maybe AE.Value),
+      -- ^ This is a Just containing the decoded contract state, if the state type is included in the schema.
+      --   If not, then this is Nothing. In this case we use the raw bytes to print the state when doing `contract show`.
+      --   The reason that JustBytes is not used in this case is that we still need the schema to print
+      --   the methods when doing `contract show`.
       wsBytes :: !ByteString -- ^ The binary-encoded contract state.
     }   
     | JustBytes


### PR DESCRIPTION
## Purpose

To show smart contract state as bytes, when schema does not include type of state. Closes https://github.com/Concordium/concordium-client/issues/34.

## Changes

* The `WithSchema` constructor of the type `ContractInfo` has been extended to contain the raw bytes, so that these can be printed `printContractInfo` in the case, where a schema is provided but doesn't include the state type.

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [x] (If necessary) I have updated the CHANGELOG.

