### PR TITLE
Warn the user that the memo size is limited.

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -2,6 +2,7 @@
 
 ## Unreleased changes
 - show smart contract state as raw bytes, if schema is provided but doesn't include the state type.
+- warn about sending transfers with oversized memos.
 
 ## 1.1.0
 - The `account show` command can receive a credential registration ID instead of a name or address.


### PR DESCRIPTION
## Purpose

Closes #68 

## Changes

Warn when sending transactions with oversized memos.

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [x] (If necessary) I have updated the CHANGELOG.
