### PR TITLE
Show amount in GTU instead of µGTU.

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -3,6 +3,8 @@
 ## Unreleased changes
 - show smart contract state as raw bytes, if schema is provided but doesn't include the state type.
 - warn about sending transfers with oversized memos.
+- show amount in GTU instead of µGTU when trying to send an encrypted amount that is larger than 
+  the encrypted balance.
 
 ## 1.1.0
 - The `account show` command can receive a credential registration ID instead of a name or address.

--- a/src/Concordium/Client/Runner.hs
+++ b/src/Concordium/Client/Runner.hs
@@ -937,7 +937,7 @@ getEncryptedAmountTransferData senderAddr ettReceiver ettAmount idx secretKey = 
               aggAmounts = foldl' (<>) _selfAmount inputEncAmounts
               totalEncryptedAmount = foldl' (+) selfDecrypted $ fmap decoder inputEncAmounts
           unless (totalEncryptedAmount >= ettAmount) $
-            logFatal [printf "The requested transfer (%s) is more than the total encrypted balance (%s)." (show ettAmount) (show totalEncryptedAmount)]
+            logFatal [printf "The requested transfer (%s) is more than the total encrypted balance (%s)." (Types.amountToString ettAmount) (Types.amountToString totalEncryptedAmount)]
           -- index indicating which encrypted amounts we used as input
           let aggIndex = case idx of
                 Nothing -> Enc.EncryptedAmountAggIndex (Enc.theAggIndex _startIndex + fromIntegral (length listOfEncryptedAmounts))


### PR DESCRIPTION
## Purpose

To show amount in GTU instead of µGTU when trying to transfer an encrypted amount that is too big. 

## Changes

The amount is now displayed in GTU.

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [x] (If necessary) I have updated the CHANGELOG.

