### PR TITLE
Log more in the transaction generator.

### DIFF
--- a/generator/Main.hs
+++ b/generator/Main.hs
@@ -73,8 +73,8 @@ go backend logit tps startValue sign startNonce = do
           (addr, tx, nextValue') <- liftIO $ sign nextNonce nextValue
           _ <- sendTx tx
           liftIO $ do
-            when logit $ putStrLn $ "Sent transaction to " ++ show addr ++ " with nonce = " ++ show nextNonce
             ct <- getCurrentTime
+            when logit $ putStrLn $ "Sent transaction to " ++ show addr ++ " with nonce = " ++ show nextNonce ++ ", hash = " ++ show (getBlockItemHash tx) ++ ", time = " ++ show ct
             let toWait = diffUTCTime nextTime ct
             when (toWait > 0) $ threadDelay (truncate $ toWait * 1e6)
           loop (nextNonce + 1) nextValue' (addUTCTime delay nextTime)


### PR DESCRIPTION
## Purpose

Log more in the transaction generator. This was requested by a user.

The log looks like
```
Sent transaction to 37EdYZFVZG2oxaCULkECdW9YrvJdgnz4wKoedEGVN2PGH37BZC with nonce = 1, hash = db0bb01bd8840f21eef4da9beb369b4f7e22fcad1bb2f17a24c72f6e708a4220, time = 2021-09-15 09:36:36.080232439 UTC
Sent transaction to 3XuDsg5SdetzXHVs1jwj2ePJzzagGSAQX51u8XiAjVooPVpWuD with nonce = 2, hash = 14fadb53cb5ee4f3fe79bd74381cdedf4fa08785ae92da755792340e4a83c42f, time = 2021-09-15 09:36:36.080710378 UTC
Sent transaction to 3arAFkeDA4NKuKV53oppgkCe4GJc6Kd7ceFJaUrkRCKg5Kz6nQ with nonce = 3, hash = 42b4b4fbf6603225d77806192a932c394c432cfa098727e1475ebe3687b37d34, time = 2021-09-15 09:36:36.41439946 UTC
```

## Checklist

- [ ] My code follows the style of this project.
- [ ] The code compiles without warnings.
- [ ] I have performed a self-review of the changes.
- [ ] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [ ] (If necessary) I have updated the CHANGELOG.

