### PR TITLE
Improve display of transfer memos.

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -2,6 +2,10 @@
 
 ## Unreleased changes
 
+- show line breaks, tabs etc. in memo transfers (when it's CBOR encoded string), instead of escaping them
+- as `\n`, `\t` etc.
+- Display memo as JSON in a more readable way.
+
 ## 1.1.1
 
 - show smart contract state as raw bytes, if schema is provided but doesn't include the state type.

--- a/src/Concordium/Client/Output.hs
+++ b/src/Concordium/Client/Output.hs
@@ -511,14 +511,14 @@ showEvent verbose = \case
     let (Types.Memo bss) = tmMemo
         invalidCBOR = printf "Could not decode memo as valid CBOR. The hex value of the memo is %s." $ show tmMemo
         bsl = BSL.fromStrict $ BSS.fromShort bss
-        str = case deserialiseFromBytes decodeString bsl of
-          Left _ -> json
+        str = case deserialiseFromBytes decodeString bsl of -- Try to decode the memo as a CBOR string
+          Left _ -> json -- if not possible, try to decode as JSON
           Right (rest, x) -> if rest == BSL.empty then
                                Text.unpack x
                              else
                                invalidCBOR
         json = case deserialiseFromBytes (decodeValue False) bsl of
-          Left _ -> invalidCBOR
+          Left _ -> invalidCBOR -- if not possible, the memo is not written in valid CBOR
           Right (rest, x) -> if rest == BSL.empty then
                                showPrettyJSON x
                              else 


### PR DESCRIPTION
## Purpose

To improve display of transfer memos. Closes https://github.com/Concordium/concordium-client/issues/73. 

## Changes

* Line breaks, tabs etc. are now shown in transfer memos instead of showing `\n`, `\t` etc.
* JSON is displayed in a more readable way, using `showPrettyJSON` instead of `showCompactPrettyJSON`.

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [x] (If necessary) I have updated the CHANGELOG.

