### PR TITLE
Add commands for registering data as CBOR strings or JSON.

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -6,6 +6,8 @@
   as `\n`, `\t` etc.
 - Display memo as JSON in a more readable way.
 - Add time units to slot duration and epoch duration in consensus status.
+- Update `register-data` command to register data as CBOR encoded strings or JSON using the new flags
+  `--string` and `--json`. Raw data can still be registered using the new flag `--raw`.
 
 ## 1.1.1
 

--- a/src/Concordium/Client/Commands.hs
+++ b/src/Concordium/Client/Commands.hs
@@ -153,7 +153,7 @@ data RegisterDataInput = RegisterString Text
 
 registerDataParser :: Parser RegisterDataInput
 registerDataParser = (RegisterString <$> strOption (long "string" <> metavar "STRING" <> help "String to be registered on chain.")) <|>
-       (RegisterJSON <$> strOption (long "json" <> metavar "FILE" <> help "File with json to registered on chain.")) <|>
+       (RegisterJSON <$> strOption (long "json" <> metavar "FILE" <> help "File with JSON to registered on chain.")) <|>
        (RegisterRaw <$> strOption (long "raw" <> metavar "FILE" <> help "File with raw bytes to be registered on chain."))
 
 data TransactionCmd

--- a/src/Concordium/Client/Commands.hs
+++ b/src/Concordium/Client/Commands.hs
@@ -22,6 +22,7 @@ module Concordium.Client.Commands
   , IdentityCmd(..)
   , IdentityShowCmd(..)
   , MemoInput(..)
+  , RegisterDataInput(..)
   ) where
 
 import Data.Text hiding (map, unlines)
@@ -144,6 +145,17 @@ memoInputParser = optional ((MemoString <$> strOption (long "memo" <> metavar "M
        (MemoJSON <$> strOption (long "memo-json" <> metavar "FILE" <> help "File with transaction memo.")) <|>
        (MemoRaw <$> strOption (long "memo-raw" <> metavar "FILE" <> help "File with raw bytes.")))
 
+
+data RegisterDataInput = RegisterString Text
+               | RegisterJSON FilePath
+               | RegisterRaw FilePath
+              deriving (Show, Read)
+
+registerDataParser :: Parser RegisterDataInput
+registerDataParser = (RegisterString <$> strOption (long "string" <> metavar "STRING" <> help "String to be registered on chain.")) <|>
+       (RegisterJSON <$> strOption (long "json" <> metavar "FILE" <> help "File with json to registered on chain.")) <|>
+       (RegisterRaw <$> strOption (long "raw" <> metavar "FILE" <> help "File with raw bytes to be registered on chain."))
+
 data TransactionCmd
   = TransactionSubmit
     { tsFile :: !FilePath
@@ -176,7 +188,7 @@ data TransactionCmd
   -- | Register data on chain.
   | TransactionRegisterData
     { -- | File containing the data.
-      trdFile :: !FilePath,
+      trdData :: !RegisterDataInput,
       -- | Options for transaction.
       trdTransactionOptions :: !(TransactionOpts (Maybe Energy))
     }
@@ -664,7 +676,7 @@ transactionRegisterDataCmd =
     "register-data"
     (info
       (TransactionRegisterData <$>
-        strArgument (metavar "FILE" <> help "File containing the data to register.") <*>
+        registerDataParser <*>
         transactionOptsParser)
       (progDesc "Register data on the chain."))
 


### PR DESCRIPTION
## Purpose

To introduce commands for registering data on chain as CBOR encoded strings and JSON. Closes https://github.com/Concordium/concordium-client/issues/75.

## Changes

* Flags `--string`, `--json` and `--raw` have been added to the command `register-data`.
* Error messages displayed when memos or registered data is too big are now arising from `memoFromBSS` and `registeredDataFromBSS` in Types.hs in concordium-base.

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [x] (If necessary) I have updated the CHANGELOG.

