### PR TITLE
Clarify info message for when default account is used

### DIFF
--- a/src/Concordium/Client/Config.hs
+++ b/src/Concordium/Client/Config.hs
@@ -843,11 +843,13 @@ getAccountConfig :: Maybe Text
 getAccountConfig account baseCfg keysDir keyMap encKey autoInit = do
   account' <- case account of
     Nothing -> do
-      logInfo [[i|"the --sender flag is not provided; using the default account name '#{defaultAccountName}'"|]]
+      logInfo [[i|the --sender flag is not provided; using the default account name '#{defaultAccountName}'|]]
       return defaultAccountName
     Just a -> return a
   namedAddr <- case getAccountAddress (bcAccountNameMap baseCfg) account' of
-                 Left err -> logFatal [err]
+                 Left err -> if isNothing account
+                             then logFatal [[i|The --sender flag was not provided; so the default account name '#{defaultAccountName}' was used, but no account with that name exists.|]]
+                             else logFatal [err]
                  Right v -> return v
 
   (bc, km, cidMap) <-

--- a/src/Concordium/Client/Runner.hs
+++ b/src/Concordium/Client/Runner.hs
@@ -1543,7 +1543,7 @@ processAccountCmd action baseCfgDir verbose backend =
 
       input <- case inputMaybe of
         Nothing -> do
-          logInfo [[i|"ACCOUNT argument not provided; using the default account name '#{defaultAccountName}'"|]]
+          logInfo [[i|the ACCOUNT argument was not provided; using the default account name '#{defaultAccountName}'|]]
           return defaultAccountName
         Just acc -> return acc
 
@@ -1553,7 +1553,9 @@ processAccountCmd action baseCfgDir verbose backend =
                   Right _ -> return input -- input is a wellformed address
                   Left _ -> case Map.lookup input (bcAccountNameMap baseCfg) of
                     Just a -> return $ Text.pack $ show a -- input is the local name of an account
-                    Nothing -> logFatal [printf "The identifier '%s' is neither a credential registration ID, the address nor the name of an account" input]
+                    Nothing -> if isNothing inputMaybe
+                               then logFatal [[i|The ACCOUNT argument was not provided; so the default account name '#{defaultAccountName}' was used, but no account with that name exists.|]]
+                               else logFatal [[i|The identifier '#{input}' is neither a credential registration ID, the address nor the name of an account|]]
 
       (accInfo, na, dec, f) <- withClient backend $ do
         -- query account


### PR DESCRIPTION
## Purpose

Clarify the info and error messages written when the `default` account is used. 
Closes #9.

## Changes

- Clarify the info message printer to include the argument/flag omission.
- Provide a better error message when the argument/flag was omitted, but no default account exists (this was particularly confusing).
- I've tried to phrase the info and error messages so that the default-account feature can be discovered by accident.
- Remove an unneeded `Maybe`. 

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [x] (If necessary) I have updated the CHANGELOG.