### PR TITLE
Fix the help text of the --grpc-ip flag. It supports hostnames as well.

### DIFF
--- a/src/Concordium/Client/Commands.hs
+++ b/src/Concordium/Client/Commands.hs
@@ -444,9 +444,9 @@ hostParser =
   strOption
     (long "grpc-ip" <>
      metavar "GRPC-IP" <>
-     value "localhost" <> -- default value
+     value "127.0.0.1" <> -- matches the default RPC listen address for the node
      showDefault <>
-     help "IP address on which the gRPC server is listening.")
+     help "Address on which the gRPC server is listening. Either an IP address or a hostname.")
 
 portParser :: Parser PortNumber
 portParser =


### PR DESCRIPTION
## Purpose

Fix the help text for the --grpc-ip flag to more accurately reflect reality.
Additionally change the default value to an IP address to avoid issues with the buggy library. This partially addresses #49 but this will still not work when the user provides localhost.

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [x] (If necessary) I have updated the CHANGELOG.
