### PR TITLE
Jenkins: Use library function for ECR login

### DIFF
--- a/scripts/tx-generator.Jenkinsfile
+++ b/scripts/tx-generator.Jenkinsfile
@@ -1,3 +1,4 @@
+@Library('concordium-pipelines') _
 pipeline {
     agent any
     environment {


### PR DESCRIPTION
## Purpose

Ensure that all pipelines use the shared Jenkins library function `ecrLogin`. This removes a lot of noise from the pipelines and ensures that a consistent method is used.

## Changes

All Jenkinsfiles are migrated to use `ecrLogin`.