### PR TITLE
Add basic support for account aliases.

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -17,6 +17,8 @@
   - Show all contracts from a module regardless of whether a schema is included
   or not.
   - Show the receive methods for contracts as well.
+- Allow sending transactions where the sender is an account alias.
+- Add command for generating aliases of an address.
 
 ## 1.1.1
 

--- a/src/Concordium/Client/Commands.hs
+++ b/src/Concordium/Client/Commands.hs
@@ -27,7 +27,7 @@ module Concordium.Client.Commands
 
 import Data.Text hiding (map, unlines)
 import Data.Version (showVersion)
-import Data.Word (Word32, Word64)
+import Data.Word (Word64)
 import Data.Time.Format.ISO8601
 import Network.HTTP2.Client
 import Options.Applicative
@@ -235,7 +235,7 @@ data AccountCmd
     {
       -- |Name or address of the account.
       asaAddress :: !Text
-    , asaAlias :: !Word32
+    , asaAlias :: !Word
     }
   deriving (Show)
 
@@ -355,7 +355,7 @@ data ContractCmd
 data TransactionOpts energyOrMaybe =
   TransactionOpts
   { toSender :: !(Maybe Text)
-  , toAlias :: !(Maybe Word32)
+  , toAlias :: !(Maybe Word)
   , toKeys :: !(Maybe FilePath)
   , toSigners :: !(Maybe Text)
   , toNonce :: !(Maybe Nonce)

--- a/src/Concordium/Client/Runner.hs
+++ b/src/Concordium/Client/Runner.hs
@@ -791,7 +791,7 @@ data TransactionConfig =
   , tcNonce :: Maybe Types.Nonce
   , tcEnergy :: Types.Energy
   , tcExpiry :: Types.TransactionExpiryTime
-  , tcAlias :: Maybe Word32 }
+  , tcAlias :: Maybe Word }
 
 -- |Resolve transaction config based on persisted config and CLI flags.
 -- If an energy cost function is provided and it returns a value which
@@ -1724,7 +1724,7 @@ processAccountCmd action baseCfgDir verbose backend =
       case getAccountAddress (bcAccountNameMap baseCfg) addrOrName of
         Left err -> logFatal [err]
         Right namedAddr ->
-          putStrLn [i|The requested alias for address #{naAddr namedAddr} is #{applyAlias (Just alias) (naAddr namedAddr)}|]
+          putStrLn [i|The requested alias for address #{naAddr namedAddr} is #{Types.createAlias (naAddr namedAddr) alias}|]
 
 -- |Process a 'module ...' command.
 processModuleCmd :: ModuleCmd -> Maybe FilePath -> Verbose -> Backend -> IO ()

--- a/src/Concordium/Client/Runner.hs
+++ b/src/Concordium/Client/Runner.hs
@@ -1434,7 +1434,8 @@ startTransaction txCfg pl confirmNonce maybeAccKeys = do
                      Nothing -> liftIO $ failOnError $ decryptAccountKeyMapInteractive esdKeys (Nothing) Nothing
   let sender = applyAlias tcAlias naAddr
   let tx = signEncodedTransaction pl sender energy nonce expiry accountKeyMap
-
+  when (isJust tcAlias) $
+      logInfo [[i|Using the alias #{sender} as the sender of the transaction instead of #{naAddr}.|]]
   sendTransactionToBaker tx defaultNetId >>= \case
     Left err -> fail err
     Right False -> fail "transaction not accepted by the baker"

--- a/src/Concordium/Client/Utils.hs
+++ b/src/Concordium/Client/Utils.hs
@@ -1,15 +1,13 @@
 {-# LANGUAGE QuasiQuotes #-}
 module Concordium.Client.Utils where
 
-import Data.Bits
 import Control.Monad.Except
 import Concordium.Types
 import Concordium.Crypto.ByteStringHelpers
 import qualified Concordium.ID.Types as IDTypes
-import qualified Data.FixedByteString as FBS
 import Data.String.Interpolate (i)
 import qualified Data.Text as Text
-import Data.Word (Word32, Word64)
+import Data.Word (Word64)
 import Text.Read
 import Data.String.Interpolate (iii)
 import qualified Data.Char as Char
@@ -93,9 +91,9 @@ energyFromStringInform s =
 -- |Try to parse an account alias counter from a string, and, if failing, inform
 -- the user what the expected format and bounds are. This is intended to be used
 -- by the options parsers.
-aliasFromStringInform :: String -> Either String Word32
+aliasFromStringInform :: String -> Either String Word
 aliasFromStringInform s =
-  -- Reading negative numbers directly to Word32 silently underflows, so this approach is necessary.
+  -- Reading negative numbers directly to Word silently underflows, so this approach is necessary.
   case readMaybe s :: Maybe Integer of
     Just a -> if a >= aliasMinBound && a <= aliasMaxBound
               then Right . fromIntegral $ a
@@ -206,8 +204,6 @@ textToDuration t = mapM measureToMs measures >>= Right . sum
               where word64MinBound = 0
                     word64MaxBound = fromIntegral (maxBound :: Word64)
 
-applyAlias :: Maybe Word32 -> AccountAddress -> AccountAddress
+applyAlias :: Maybe Word -> AccountAddress -> AccountAddress
 applyAlias Nothing addr = addr
-applyAlias (Just alias) (IDTypes.AccountAddress addr) =
-      IDTypes.AccountAddress ((FBS.encodeInteger (toInteger alias) .&. mask) .|. (addr .&. (complement mask)))
-    where mask = FBS.encodeInteger 0xffffff
+applyAlias (Just alias) addr = createAlias addr alias


### PR DESCRIPTION
## Purpose

Add ability to send transactions via account aliases.
This is a minimal change to enable testing. The account storage remains the same and we do not currently support having multiple aliases with the same keys stored on disk. That can be added in a followup PR if needed.

## Changes

- Add ability to send using an alias.
- Add ability to generate account aliases.

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [x] (If necessary) I have updated the CHANGELOG.