### PR TITLE
Release version 3.0.0 of concordium-client.

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,6 +1,6 @@
 # Changelog for concordium-client
 
-## Unreleased changes
+## 3.0.0
 
 - show line breaks, tabs etc. in memo transfers (when it's CBOR encoded string), instead of escaping them
   as `\n`, `\t` etc.

--- a/concordium-client.cabal
+++ b/concordium-client.cabal
@@ -5,7 +5,7 @@ cabal-version: 2.0
 -- see: https://github.com/sol/hpack
 
 name:           concordium-client
-version:        1.1.1
+version:        3.0.0
 description:    Please see the README on GitHub at <https://github.com/Concordium/concordium-client#readme>
 homepage:       https://github.com/Concordium/concordium-client#readme
 bug-reports:    https://github.com/Concordium/concordium-client/issues

--- a/package.yaml
+++ b/package.yaml
@@ -1,5 +1,5 @@
 name:                concordium-client
-version:             1.1.1
+version:             3.0.0
 github:              "Concordium/concordium-client"
 author:              "Concordium"
 maintainer:          "developers@concordium.com"


### PR DESCRIPTION
## Purpose

Bump version to 3 to match the new node version.

## Changes

No code changes, just updated version.