### PR TITLE
Rename all uses of GTU to CCD.

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,5 +1,12 @@
 # Changelog for concordium-client
 
+## 3.0.1
+
+- rename GTU token to CCD
+- rename send-gtu, send-gtu-scheduled and send-gtu-encrypted to send,
+  send-scheduled and send-shielded.
+- rename account encrypt/decrypt to account shield/unshield
+
 ## 3.0.0
 
 - show line breaks, tabs etc. in memo transfers (when it's CBOR encoded string), instead of escaping them

--- a/docs/terminology.txt
+++ b/docs/terminology.txt
@@ -4,13 +4,13 @@ Glossary:
 * Best branch/chain: The branch in the block tree that contains the most blocks (and all finalized blocks).
 * Node: A process running the P2P software.
 * Peer: A peer of a node is another node connected to it.
-* Transaction: A piece of information stored in a block on the chain. Can be GTU transfer, module or account deployment, etc.
+* Transaction: A piece of information stored in a block on the chain. Can be CCD transfer, module or account deployment, etc.
 * Consensus: Agreement on how blocks are generated and when they're valid and finalized.
 * Account: Accounts represent external users of the chain and are the ones who always initiate non-consensus related actions, i.e., sending transactions.
 * Reward account: Special account for bakers and finalizers that have some ability to change the parameters (e.g. keys) of the baker.
-* Account: An entity holding GTUs. Bakers, contracts, and other stakeholders have accounts.
+* Account: An entity holding CCDs. Bakers, contracts, and other stakeholders have accounts.
 * Module: An Acorn module that defines zero or more smart contracts.
-* Instance: An instance of a smart contract. Smart contracts may hold GTUs.
+* Instance: An instance of a smart contract. Smart contracts may hold CCDs.
 * Birk parameters: "lottery" state.
 * Skov: The tree layer which stores all the consensus information, e.g., which blocks exist, which are final etc.
 * Branch/parent/ancestor/child: Refers to relation between blocks as nodes in a tree in the usual way.

--- a/middleware/README.md
+++ b/middleware/README.md
@@ -57,68 +57,6 @@ SIMPLEID_URL="http://localhost:8000" \
 middleware
 ```
 
-
-### Scenario: Development testing
-
-See the bottom of `middleware/Api.hs` for the `debugTestFullProvision` function.
-
-To run it:
-
-```
-cd concordium-client
-stack ghci --flag "concordium-client:middleware"
-# Pick middleware option
-```
-
-You can boot `ghci` with the supported ENV vars:
-
-```
-NODE_URL="localhost:11100" \
-SIMPLEID_URL="http://localhost:8000" \
-stack ghci --flag "concordium-client:middleware"
-```
-
-Then in GHCI you can do:
-
-```
-λ: :r
-...
-Ok, 16 modules loaded.
-λ: import Api
-λ: debugTestFullProvision
-```
-
-This will currently:
-
-- Call `simple_id_server` to generate an ID
-- Call `simple_id_server` to generate credentials for that ID
-- Bump the next nonce using ElasticSearch*
-- Call gRPC with a `DeployCredentials` transaction
-- Call gRPC with a `Transfer` for a GTU drop to the new account
-- Write the bare transaction into ElasticSearch
-
-<sub>&#42;This allows multiple transactions to be submitted in quick succession without colliding nonces</sub>
-
-
-Use `:r` to reload ghci again on further changes.
-
-The last thing you should see if successful is something like:
-
-```
-✅ Requesting GTU Drop for AddressAccount 3uVGUijtdD5JLJmmf3Q4pqe1y4H3PHfW469GphtprZuTfTRxex
-✅ got nonceQueryResponse, progressing...
-Installing hook for transaction 5dcaf8d6d204b54988328d1bf6899690d185d6354a261b82a30402b7da5e2a4b
-{
-    "status": "absent",
-    "results": [],
-    "expires": "2020-01-31T16:53:14.0571333Z",
-    "transactionHash": "5dcaf8d6d204b54988328d1bf6899690d185d6354a261b82a30402b7da5e2a4b"
-}
-✅ Transaction sent to the baker and hooked: 5dcaf8d6d204b54988328d1bf6899690d185d6354a261b82a30402b7da5e2a4b
-TransactionJSON {metadata ...
-... etc
-```
-
 ### Configuration and data directories
 
 Configuration and data directories can be customized via the `CFG_DIR` and

--- a/src/Concordium/Client/Cli.hs
+++ b/src/Concordium/Client/Cli.hs
@@ -296,7 +296,7 @@ data AccountInfoResult = AccountInfoResult
   , airCredentials :: !(OrdMap.Map IDTypes.CredentialIndex (Versioned IDTypes.AccountCredential))
     -- | Account's encrypted amount.
   , airEncryptedAmount :: !AccountEncryptedAmount
-    -- | The public key to use when sending encrypted transfers to the account.
+    -- | The public key to use when sending shielded transfers to the account.
   , airEncryptionKey :: !IDTypes.AccountEncryptionKey
   , airReleaseSchedule :: !AccountInfoReleaseSchedule
   }

--- a/src/Concordium/Client/Commands.hs
+++ b/src/Concordium/Client/Commands.hs
@@ -674,9 +674,9 @@ transactionEncryptedTransferCmd = command "send-shielded" sendEncryptedInfo
              transactionOptsParser <*>
              strOption (long "receiver" <> metavar "RECEIVER-ACCOUNT" <> help "Address of the receiver.") <*>
              option (eitherReader amountFromStringInform) (long "amount" <> metavar "CCD-AMOUNT" <> help "Amount of CCDs to send.") <*>
-             optional (option auto (long "index" <> metavar "INDEX" <> help "Optionally specify the index up to which incoming encrypted amounts should be used.")) <*>
+             optional (option auto (long "index" <> metavar "INDEX" <> help "Optionally specify the index up to which incoming shielded amounts should be used.")) <*>
              memoInputParser)
-            (progDesc "Transfer CCD from the encrypted balance of the account to the encrypted balance of another account.")
+            (progDesc "Transfer CCD from the shielded balance of the account to the shielded balance of another account.")
 
 transactionRegisterDataCmd :: Mod CommandFields TransactionCmd
 transactionRegisterDataCmd =
@@ -732,8 +732,8 @@ accountEncryptCmd =
     (info
       (AccountEncrypt <$>
         transactionOptsParser <*>
-        option (eitherReader amountFromStringInform) (long "amount" <> metavar "CCD-AMOUNT" <> help "The amount to transfer to encrypted balance."))
-      (progDesc "Transfer an amount from public to encrypted balance of the account."))
+        option (eitherReader amountFromStringInform) (long "amount" <> metavar "CCD-AMOUNT" <> help "The amount to transfer to shielded balance."))
+      (progDesc "Transfer an amount from public to shielded balance of the account."))
 
 accountDecryptCmd :: Mod CommandFields AccountCmd
 accountDecryptCmd =
@@ -743,8 +743,8 @@ accountDecryptCmd =
       (AccountDecrypt <$>
         transactionOptsParser <*>
         option (maybeReader amountFromString) (long "amount" <> metavar "CCD-AMOUNT" <> help "The amount to transfer to public balance.") <*>
-        optional (option auto (long "index" <> metavar "INDEX" <> help "Optionally specify the index up to which encrypted amounts should be combined.")))
-      (progDesc "Transfer an amount from encrypted to public balance of the account."))
+        optional (option auto (long "index" <> metavar "INDEX" <> help "Optionally specify the index up to which shielded amounts should be combined.")))
+      (progDesc "Transfer an amount from shielded to public balance of the account."))
 
 accountUpdateKeysCmd :: Mod CommandFields AccountCmd
 accountUpdateKeysCmd =

--- a/src/Concordium/Client/Output.hs
+++ b/src/Concordium/Client/Output.hs
@@ -306,7 +306,7 @@ printContractInfo CI.ContractInfo{..} namedOwner namedModRef = do
   tell [ [i|Contract:        #{contractName}|]
        , [i|Owner:           #{owner}|]
        , [i|ModuleReference: #{showNamedModuleRef namedModRef}|]
-       , [i|Balance:         #{Types.amountToString ciAmount} CCD|]
+       , [i|Balance:         #{showCcd ciAmount}|]
        , [i|State size:      #{ciSize} bytes|]]
   tell state
   tell [ [i|Methods:|]]

--- a/src/Concordium/Client/Output.hs
+++ b/src/Concordium/Client/Output.hs
@@ -161,14 +161,14 @@ printAccountInfo :: (Types.Epoch -> UTCTime) -> NamedAddress -> AccountInfoResul
 printAccountInfo epochsToUTC addr a verbose showEncrypted mEncKey= do
   tell ([ [i|Local names:            #{showNameList $ naNames addr}|]
         , [i|Address:                #{naAddr addr}|]
-        , [i|Balance:                #{showGtu $ airAmount a}|]
+        , [i|Balance:                #{showCcd $ airAmount a}|]
         ] ++
        case totalRelease $ airReleaseSchedule a of
          0 -> []
-         tot -> (printf "Release schedule:       total %s" (showGtu tot)) :
+         tot -> (printf "Release schedule:       total %s" (showCcd tot)) :
                (map (\ReleaseScheduleItem{..} -> printf "   %s:               %s scheduled by the transactions: %s."
                                                 (showTimeFormatted (Time.timestampToUTCTime rsiTimestamp))
-                                                (showGtu rsiAmount)
+                                                (showCcd rsiAmount)
                                                 (intercalate ", " $ map show rsiTransactions))
                  (releaseSchedule $ airReleaseSchedule a))
        ++ [ printf "Nonce:                  %s" (show $ airNonce a)
@@ -198,7 +198,7 @@ printAccountInfo epochsToUTC addr a verbose showEncrypted mEncKey= do
         Just (encKey, globalContext) -> do
              let table = Enc.computeTable globalContext (2^(16::Int))
                  decoder = Enc.decryptAmount table encKey
-                 printer x = let decoded = decoder x in "(" ++ showGtu decoded ++ ") " ++ showEncryptedAmount x
+                 printer x = let decoded = decoder x in "(" ++ showCcd decoded ++ ") " ++ showEncryptedAmount x
                  showableSelfDecryptedAmount = printer (Types._selfAmount $ airEncryptedAmount a)
                  incomingAmountsList = Types.getIncomingAmountsList $ airEncryptedAmount a
                  showableIncomingAmountsList =  printer <$>  incomingAmountsList
@@ -211,14 +211,14 @@ printAccountInfo epochsToUTC addr a verbose showEncrypted mEncKey= do
     Nothing -> tell ["Baker: none"]
     Just bk -> do
       let bkid = [i|Baker: \##{show . aibiIdentity . abirAccountBakerInfo $ bk}|]
-          stkstr = [i| - Staked amount: #{showGtu . abirStakedAmount $ bk}|]
+          stkstr = [i| - Staked amount: #{showCcd . abirStakedAmount $ bk}|]
       case abirBakerPendingChange bk of
         NoChange -> tell [ bkid
                          , stkstr ]
         RemoveBaker e -> tell [ [i|#{bkid} to be removed at epoch #{e} (#{epochsToUTC e})|]
                               , stkstr ]
         ReduceStake n e -> tell [ bkid
-                                , [i|#{stkstr} to be updated to #{showGtu n} at epoch #{e} (#{epochsToUTC e})|] ]
+                                , [i|#{stkstr} to be updated to #{showCcd n} at epoch #{e} (#{epochsToUTC e})|] ]
       tell [[i| - Restake earnings: #{showYesNo . abirStakeEarnings $ bk}|]]
 
   tell [ "" ]
@@ -306,7 +306,7 @@ printContractInfo CI.ContractInfo{..} namedOwner namedModRef = do
   tell [ [i|Contract:        #{contractName}|]
        , [i|Owner:           #{owner}|]
        , [i|ModuleReference: #{showNamedModuleRef namedModRef}|]
-       , [i|Balance:         #{Types.amountToString ciAmount} GTU|]
+       , [i|Balance:         #{Types.amountToString ciAmount} CCD|]
        , [i|State size:      #{ciSize} bytes|]]
   tell state
   tell [ [i|Methods:|]]
@@ -560,7 +560,7 @@ showOutcomeCost :: Types.TransactionSummary -> String
 showOutcomeCost outcome = showCost (Types.tsCost outcome) (Types.tsEnergyCost outcome)
 
 showCost :: Types.Amount -> Types.Energy -> String
-showCost gtu nrg = printf "%s (%s)" (showGtu gtu) (showNrg nrg)
+showCost gtu nrg = printf "%s (%s)" (showCcd gtu) (showNrg nrg)
 
 showOutcomeResult :: Verbose -> Types.ValidResult -> [String]
 showOutcomeResult verbose = \case
@@ -598,7 +598,7 @@ showEvent verbose = \case
     verboseOrNothing $ printf "credential with registration '%s' deployed onto account '%s'" (show ecdRegId) (show ecdAccount)
   Types.BakerAdded{..} ->
     let restakeString :: String = if ebaRestakeEarnings then "Earnings are added to the stake." else "Earnings are not added to the stake."
-    in Just $ printf "baker %s added, staking %s GTU. %s" (showBaker ebaBakerId ebaAccount) (Types.amountToString ebaStake) restakeString
+    in Just $ printf "baker %s added, staking %s CCD. %s" (showBaker ebaBakerId ebaAccount) (Types.amountToString ebaStake) restakeString
   Types.BakerRemoved{..} ->
     verboseOrNothing $ printf "baker %s, removed" (showBaker ebrBakerId ebrAccount) (show ebrBakerId)
   Types.BakerStakeIncreased{..} ->
@@ -613,14 +613,14 @@ showEvent verbose = \case
     verboseOrNothing $ [i|credentials on account #{cuAccount} have been updated.\nCredentials #{cuRemovedCredIds} have been removed, and credentials #{cuNewCredIds} have been added.\nThe new account threshold is #{cuNewThreshold}.|]
 
   Types.CredentialKeysUpdated cid -> verboseOrNothing $ printf "credential keys updated for credential with credId %s" (show cid)
-  Types.NewEncryptedAmount{..} -> verboseOrNothing $ printf "encrypted amount received on account '%s' with index '%s'" (show neaAccount) (show neaNewIndex)
-  Types.EncryptedAmountsRemoved{..} -> verboseOrNothing $ printf "encrypted amounts removed on account '%s' up to index '%s' with a resulting self encrypted amount of '%s'" (show earAccount) (show earUpToIndex) (show earNewAmount)
+  Types.NewEncryptedAmount{..} -> verboseOrNothing $ printf "shielded amount received on account '%s' with index '%s'" (show neaAccount) (show neaNewIndex)
+  Types.EncryptedAmountsRemoved{..} -> verboseOrNothing $ printf "shielded amounts removed on account '%s' up to index '%s' with a resulting self shielded amount of '%s'" (show earAccount) (show earUpToIndex) (show earNewAmount)
   Types.AmountAddedByDecryption{..} -> verboseOrNothing $ printf "transferred '%s' tokens from the shielded balance to the public balance on account '%s'" (show aabdAmount) (show aabdAccount)
-  Types.EncryptedSelfAmountAdded{..} -> verboseOrNothing $ printf "transferred '%s' tokens from the public balance to the shielded balance on account '%s' with a resulting self encrypted balance of '%s'" (show eaaAmount) (show eaaAccount) (show eaaNewAmount)
+  Types.EncryptedSelfAmountAdded{..} -> verboseOrNothing $ printf "transferred '%s' tokens from the public balance to the shielded balance on account '%s' with a resulting self shielded balance of '%s'" (show eaaAmount) (show eaaAccount) (show eaaNewAmount)
   Types.UpdateEnqueued{..} ->
     verboseOrNothing $ printf "Enqueued chain update, effective at %s:\n%s" (showTimeFormatted (timeFromTransactionExpiryTime ueEffectiveTime)) (show uePayload)
   Types.TransferredWithSchedule{..} ->
-    verboseOrNothing $ printf "Sent transfer with schedule %s" (intercalate ", " . map (\(a, b) -> showTimeFormatted (Time.timestampToUTCTime a) ++ ": " ++ showGtu b) $ etwsAmount)
+    verboseOrNothing $ printf "Sent transfer with schedule %s" (intercalate ", " . map (\(a, b) -> showTimeFormatted (Time.timestampToUTCTime a) ++ ": " ++ showCcd b) $ etwsAmount)
   Types.DataRegistered{ } ->
     verboseOrNothing [i|Registered data on chain.|]
   Types.TransferMemo{..} ->
@@ -731,9 +731,9 @@ showRejectReason verbose = \case
   Types.InvalidAccountThreshold ->
     "account threshold exceeds the number of credentials"
   Types.InvalidEncryptedAmountTransferProof ->
-    "the proof for the encrypted transfer doesn't validate"
+    "the proof for the shielded transfer doesn't validate"
   Types.EncryptedAmountSelfTransfer acc ->
-    printf "attempted to make an encrypted transfer to the same account '%s'" (show acc)
+    printf "attempted to make a shielded transfer to the same account '%s'" (show acc)
   Types.InvalidTransferToPublicProof ->
     "the proof for the secret to public transfer doesn't validate"
   Types.InvalidIndexOnEncryptedTransfer ->
@@ -755,8 +755,8 @@ showRejectReason verbose = \case
   Types.CredentialHolderDidNotSign -> [i|credential holder did not sign the credential key update|]
   Types.StakeUnderMinimumThresholdForBaking -> "the desired stake is under the minimum threshold for baking"
   Types.NotAllowedMultipleCredentials -> "the account is not allowed to have multiple credentials"
-  Types.NotAllowedToReceiveEncrypted -> "the account is not allowed to receive encrypted transfers"
-  Types.NotAllowedToHandleEncrypted -> "the account is not allowed handle encrypted amounts"
+  Types.NotAllowedToReceiveEncrypted -> "the account is not allowed to receive shielded transfers"
+  Types.NotAllowedToHandleEncrypted -> "the account is not allowed handle shielded amounts"
 
 -- CONSENSUS
 
@@ -883,9 +883,9 @@ printAnonymityRevokers vals = do
 
 -- AMOUNT AND ENERGY
 
--- |Standardized method of displaying an amount as GTU.
-showGtu :: Types.Amount -> String
-showGtu = printf "%s GTU" . Types.amountToString
+-- |Standardized method of displaying an amount as CCD.
+showCcd :: Types.Amount -> String
+showCcd = printf "%s CCD" . Types.amountToString
 
 -- |Standardized method of displaying energy as NRG.
 showNrg :: Types.Energy -> String

--- a/src/Concordium/Client/Runner.hs
+++ b/src/Concordium/Client/Runner.hs
@@ -1200,7 +1200,7 @@ encryptedTransferTransactionConfirm EncryptedTransferTransactionConfig{..} confi
         = ettTransactionCfg
 
   logInfo
-    [ printf "transferring %s CCD from encrypted balance of account %s to %s" (Types.amountToString ettAmount) (showNamedAddress addr) (showNamedAddress ettReceiver)
+    [ printf "transferring %s CCD from shielded balance of account %s to %s" (Types.amountToString ettAmount) (showNamedAddress addr) (showNamedAddress ettReceiver)
     , printf "allowing up to %s to be spent as transaction fee" (showNrg energy)
     , printf "transaction expires on %s" (showTimeFormatted $ timeFromTransactionExpiryTime expiry) ]
 
@@ -1383,7 +1383,7 @@ accountEncryptTransactionConfirm AccountEncryptTransactionConfig{..} confirm = d
 
 
   logInfo $
-    [ printf "transferring %s CCD from public to encrypted balance of account %s" (Types.amountToString aeAmount) (showNamedAddress addr)
+    [ printf "transferring %s CCD from public to shielded balance of account %s" (Types.amountToString aeAmount) (showNamedAddress addr)
     , printf "allowing up to %s to be spent as transaction fee" (showNrg energy)
     , printf "transaction expires on %s" (showTimeFormatted $ timeFromTransactionExpiryTime expiry) ]
 
@@ -1401,7 +1401,7 @@ accountDecryptTransactionConfirm AccountDecryptTransactionConfig{..} confirm = d
         = adTransactionCfg
 
   logInfo $
-    [ printf "transferring %s CCD from encrypted to public balance of account %s" (Types.amountToString (Enc.stpatdTransferAmount adTransferData)) (showNamedAddress addr)
+    [ printf "transferring %s CCD from shielded to public balance of account %s" (Types.amountToString (Enc.stpatdTransferAmount adTransferData)) (showNamedAddress addr)
     , printf "allowing up to %s to be spent as transaction fee" (showNrg energy)
     , printf "transaction expires on %s" (showTimeFormatted $ timeFromTransactionExpiryTime expiry) ]
 

--- a/src/Concordium/Client/Runner.hs
+++ b/src/Concordium/Client/Runner.hs
@@ -567,7 +567,7 @@ processTransactionCmd action baseCfgDir verbose backend =
       -- TODO This works but output doesn't make sense if transaction is already committed/finalized.
       --      It should skip already completed steps.
       -- withClient backend $ tailTransaction_ hash
-    TransactionSendGtu receiver amount maybeMemo txOpts -> do
+    TransactionSendCcd receiver amount maybeMemo txOpts -> do
       baseCfg <- getBaseConfig baseCfgDir verbose
       when verbose $ do
         runPrinter $ printBaseConfig baseCfg
@@ -1000,12 +1000,12 @@ getBakerUpdateStakeTransactionCfg txCfg newAmount cooldownDate = do
   case airBaker of
     Nothing -> logFatal [[i|Account #{senderAddr} is not a baker, so cannot update its stake.|]]
     Just aibresult -> do
-      when (airAmount < newAmount) $ logFatal [[i|Account balance (#{showGtu airAmount}) is lower than the new amount requested to be staked (#{showGtu newAmount}).|]]
+      when (airAmount < newAmount) $ logFatal [[i|Account balance (#{showCcd airAmount}) is lower than the new amount requested to be staked (#{showCcd newAmount}).|]]
       -- Check if stake is being decreased, ask for confirmation if so if so
       if (newAmount < abirStakedAmount aibresult)
       then do
         logWarn ["The new staked value appears to be lower than the amount currently staked on chain by this baker."]
-        logWarn ["Decreasing the amount a baker is staking will lock the stake of the baker for a cooldown period before the GTU are made available."]
+        logWarn ["Decreasing the amount a baker is staking will lock the stake of the baker for a cooldown period before the CCD are made available."]
         logWarn ["During this period it is not possible to update the baker's stake, or stop the baker."]
         logWarn [[i|The current baker cooldown would last until approximately #{cooldownDate}|]]
         confirmed <- askConfirmation $ Just "Confirm that you want to update the baker's stake"
@@ -1014,15 +1014,15 @@ getBakerUpdateStakeTransactionCfg txCfg newAmount cooldownDate = do
           { bustcNewAmount = newAmount
           , bustcTransactionCfg = txCfg }
       else do
-        logInfo ["Note that decreasing the amount a baker is staking will lock the stake of the baker for a cooldown period before the GTU are made available."]
+        logInfo ["Note that decreasing the amount a baker is staking will lock the stake of the baker for a cooldown period before the CCD are made available."]
         logInfo ["During this period it is not possible to update the baker's stake, or stop the baker."]
         logInfo [[i|The current baker cooldown would last until approximately #{cooldownDate}|]]
-        -- Check if staked amount is greater than 95% of total GTU on the account, and warn user if so
+        -- Check if staked amount is greater than 95% of total CCD on the account, and warn user if so
         if ((newAmount * 100) > (airAmount * 95))
         then do
-          logWarn ["You are attempting to stake >95% of your total GTU on this account. Staked GTU is not available for spending."]
-          logWarn ["Be aware that updating or stopping your baker in the future will require some amount of non-staked GTU to pay for the transactions to do so."]
-          confirmed <- askConfirmation $ Just "Confirm that you wish to stake this much GTU"
+          logWarn ["You are attempting to stake >95% of your total CCD on this account. Staked CCD is not available for spending."]
+          logWarn ["Be aware that updating or stopping your baker in the future will require some amount of non-staked CCD to pay for the transactions to do so."]
+          confirmed <- askConfirmation $ Just "Confirm that you wish to stake this much CCD"
           unless confirmed exitTransactionCancelled
           return BakerUpdateStakeTransactionConfig
             { bustcNewAmount = newAmount
@@ -1163,7 +1163,7 @@ transferTransactionConfirm ttxCfg confirm = do
         , ttcReceiver = toAddress }
         = ttxCfg
 
-  logSuccess [ printf "sending %s from %s to %s" (showGtu amount) (showNamedAddress fromAddress) (showNamedAddress toAddress)
+  logSuccess [ printf "sending %s from %s to %s" (showCcd amount) (showNamedAddress fromAddress) (showNamedAddress toAddress)
              , printf "allowing up to %s to be spent as transaction fee" (showNrg energy)
              , printf "transaction expires on %s" (showTimeFormatted $ timeFromTransactionExpiryTime expiryTs) ]
   when confirm $ do
@@ -1183,8 +1183,8 @@ transferWithScheduleTransactionConfirm ttxCfg confirm = do
         , twstcReceiver = toAddress }
         = ttxCfg
 
-  logSuccess [ printf "sending GTUs from %s to %s" (showNamedAddress fromAddress) (showNamedAddress toAddress)
-             , printf "with the following release schedule:\n%swith a total amount of %s" (unlines $ map (\(a, b) -> showTimeFormatted (Time.timestampToUTCTime a) ++ ": " ++ showGtu b) schedule) (showGtu $ foldl' (\acc (_, x) -> acc + x) 0 schedule)
+  logSuccess [ printf "sending CCDs from %s to %s" (showNamedAddress fromAddress) (showNamedAddress toAddress)
+             , printf "with the following release schedule:\n%swith a total amount of %s" (unlines $ map (\(a, b) -> showTimeFormatted (Time.timestampToUTCTime a) ++ ": " ++ showCcd b) schedule) (showCcd $ foldl' (\acc (_, x) -> acc + x) 0 schedule)
              , printf "allowing up to %s to be spent as transaction fee" (showNrg energy)
              , printf "transaction expires on %s" (showTimeFormatted $ timeFromTransactionExpiryTime expiryTs) ]
   when confirm $ do
@@ -1200,7 +1200,7 @@ encryptedTransferTransactionConfirm EncryptedTransferTransactionConfig{..} confi
         = ettTransactionCfg
 
   logInfo
-    [ printf "transferring %s GTU from encrypted balance of account %s to %s" (Types.amountToString ettAmount) (showNamedAddress addr) (showNamedAddress ettReceiver)
+    [ printf "transferring %s CCD from encrypted balance of account %s to %s" (Types.amountToString ettAmount) (showNamedAddress addr) (showNamedAddress ettReceiver)
     , printf "allowing up to %s to be spent as transaction fee" (showNrg energy)
     , printf "transaction expires on %s" (showTimeFormatted $ timeFromTransactionExpiryTime expiry) ]
 
@@ -1246,7 +1246,7 @@ bakerAddTransaction baseCfg txOpts f batcBakingStake batcRestakeEarnings confirm
   txCfg@TransactionConfig{..} <- getTransactionCfg baseCfg txOpts nrgCost
 
   logSuccess [ printf "adding baker with account %s" (show (naAddr $ esdAddress tcEncryptedSigningData))
-             , printf "initial stake will be %s GTU" (Types.amountToString batcBakingStake)
+             , printf "initial stake will be %s CCD" (Types.amountToString batcBakingStake)
              , if batcRestakeEarnings then "Rewards will be automatically added to the baking stake." else "Rewards will _not_ be automatically added to the baking stake."
              , printf "allowing up to %s to be spent as transaction fee" (showNrg tcEnergy) ]
   when confirm $ do
@@ -1309,7 +1309,7 @@ bakerUpdateStakeTransactionConfirm brtxCfg confirm = do
         , bustcNewAmount = newAmount }
         = brtxCfg
 
-  logSuccess [ printf "submitting transaction to update stake of baker to '%s'" (showGtu newAmount)
+  logSuccess [ printf "submitting transaction to update stake of baker to '%s'" (showCcd newAmount)
              , printf "allowing up to %s to be spent as transaction fee" (showNrg energy) ]
   when confirm $ do
     confirmed <- askConfirmation Nothing
@@ -1383,7 +1383,7 @@ accountEncryptTransactionConfirm AccountEncryptTransactionConfig{..} confirm = d
 
 
   logInfo $
-    [ printf "transferring %s GTU from public to encrypted balance of account %s" (Types.amountToString aeAmount) (showNamedAddress addr)
+    [ printf "transferring %s CCD from public to encrypted balance of account %s" (Types.amountToString aeAmount) (showNamedAddress addr)
     , printf "allowing up to %s to be spent as transaction fee" (showNrg energy)
     , printf "transaction expires on %s" (showTimeFormatted $ timeFromTransactionExpiryTime expiry) ]
 
@@ -1401,7 +1401,7 @@ accountDecryptTransactionConfirm AccountDecryptTransactionConfig{..} confirm = d
         = adTransactionCfg
 
   logInfo $
-    [ printf "transferring %s GTU from encrypted to public balance of account %s" (Types.amountToString (Enc.stpatdTransferAmount adTransferData)) (showNamedAddress addr)
+    [ printf "transferring %s CCD from encrypted to public balance of account %s" (Types.amountToString (Enc.stpatdTransferAmount adTransferData)) (showNamedAddress addr)
     , printf "allowing up to %s to be spent as transaction fee" (showNrg energy)
     , printf "transaction expires on %s" (showTimeFormatted $ timeFromTransactionExpiryTime expiry) ]
 
@@ -1883,7 +1883,7 @@ processContractCmd action baseCfgDir verbose backend =
                                                   and additional energy is needed to complete the initialization|]]
 
       logInfo [ [i|initialize contract '#{contrName}' from module '#{citcModuleRef ciCfg}' with |]
-                  ++ paramsMsg paramsFileJSON paramsFileBinary ++ [i| Sending #{Types.amountToString $ citcAmount ciCfg} GTU.|]
+                  ++ paramsMsg paramsFileJSON paramsFileBinary ++ [i| Sending #{Types.amountToString $ citcAmount ciCfg} CCD.|]
               , [i|allowing up to #{showNrg energy} to be spent as transaction fee|]
               , [i|transaction expires on #{showTimeFormatted $ timeFromTransactionExpiryTime expiryTs}|]]
 
@@ -1919,7 +1919,7 @@ processContractCmd action baseCfgDir verbose backend =
                                                   and additional energy is needed to complete the update|]]
 
       logInfo [ [i|update contract '#{cutcContrName cuCfg}' using the function '#{receiveName}' with |]
-                  ++ paramsMsg paramsFileJSON paramsFileBinary ++ [i| Sending #{Types.amountToString $ cutcAmount cuCfg} GTU.|]
+                  ++ paramsMsg paramsFileJSON paramsFileBinary ++ [i| Sending #{Types.amountToString $ cutcAmount cuCfg} CCD.|]
               , [i|allowing up to #{showNrg energy} to be spent as transaction fee|]
               , [i|transaction expires on #{showTimeFormatted $ timeFromTransactionExpiryTime expiryTs}|]]
 
@@ -2442,31 +2442,31 @@ processBakerCmd action baseCfgDir verbose backend =
             let cannotAfford = airAmount - gtuTransactionPrice < initialStake
             minimumBakerStake <- getBakerStakeThresholdOrDie
             when (initialStake < minimumBakerStake) $ do
-              logWarn [[i|The staked amount (#{showGtu initialStake}) is lower than the minimum baker stake threshold (#{showGtu minimumBakerStake}).|]]
+              logWarn [[i|The staked amount (#{showCcd initialStake}) is lower than the minimum baker stake threshold (#{showCcd minimumBakerStake}).|]]
               confirmed <- askConfirmation $ Just "This transaction will most likely be rejected by the chain, do you wish to send it anyway"
               unless confirmed exitTransactionCancelled
             when cannotAfford $ do
-              logWarn [[i|Account balance (#{showGtu airAmount}) minus the cost of the transaction (#{showGtu gtuTransactionPrice}) is lower than the amount requested to be staked (#{showGtu initialStake}).|]]
+              logWarn [[i|Account balance (#{showCcd airAmount}) minus the cost of the transaction (#{showCcd gtuTransactionPrice}) is lower than the amount requested to be staked (#{showCcd initialStake}).|]]
               confirmed <- askConfirmation $ Just "This transaction will most likely be rejected by the chain, do you wish to send it anyway"
               unless confirmed exitTransactionCancelled
-            -- Check if staked amount is greater than 95% of total GTU on the account, and warn user if so
+            -- Check if staked amount is greater than 95% of total CCD on the account, and warn user if so
             when ((initialStake * 100) > (airAmount * 95) && not cannotAfford) $ do
-              logWarn ["You are attempting to stake >95% of your total GTU on this account. Staked GTU is not available for spending."]
-              logWarn ["Be aware that updating or stopping your baker in the future will require some amount of non-staked GTU to pay for the transactions to do so."]
-              confirmed <- askConfirmation $ Just "Confirm that you wish to stake this much GTU"
+              logWarn ["You are attempting to stake >95% of your total CCD on this account. Staked CCD is not available for spending."]
+              logWarn ["Be aware that updating or stopping your baker in the future will require some amount of non-staked CCD to pay for the transactions to do so."]
+              confirmed <- askConfirmation $ Just "Confirm that you wish to stake this much CCD"
               unless confirmed exitTransactionCancelled
             sendAndMaybeOutputCredentials bakerKeys wasEncrypted bakerKeysFile outputFile txCfg pl intOpts
         where
           -- General function to fetch NrgGtu rate
-          -- This functionality is going to be more generally used in an upcoming branch adding GTU prices to NRG printouts across the client.
+          -- This functionality is going to be more generally used in an upcoming branch adding CCD prices to NRG printouts across the client.
           -- Invoking it directly here to avoid extra work on compatability/refactoring in the future
           getNrgGtuRate :: ClientMonad IO Types.EnergyRate
           getNrgGtuRate = do 
             blockSummary <- getFromJson =<< withBestBlockHash Nothing getBlockSummary
             case blockSummary of
               Nothing -> do
-                logError ["Failed to retrieve NRG-GTU rate from the chain using best block hash, unable to estimate GTU cost"]
-                logError ["Falling back to default behaviour, all GTU values derived from NRG will be set to 0"]
+                logError ["Failed to retrieve NRG-CCD rate from the chain using best block hash, unable to estimate CCD cost"]
+                logError ["Falling back to default behaviour, all CCD values derived from NRG will be set to 0"]
                 return 0
               Just bsr -> do
                 return $ _cpEnergyRate $ bsurChainParameters $ bsrUpdates bsr
@@ -2499,7 +2499,7 @@ processBakerCmd action baseCfgDir verbose backend =
           Just cpr -> do
             -- Warn user that stopping a baker incurs the baker cooldown timer
             cooldownDate <- getBakerCooldown cpr
-            logWarn ["Stopping a baker that is staking will lock the stake of the baker for a cooldown period before the GTU are made available."]
+            logWarn ["Stopping a baker that is staking will lock the stake of the baker for a cooldown period before the CCD are made available."]
             logWarn ["During this period it is not possible to update the baker's stake, or restart the baker."]
             logWarn [[i|The current baker cooldown would last until approximately #{cooldownDate}|]]
             confirmed <- askConfirmation $ Just "Confirm that you want to send the transaction to stop this baker"

--- a/src/Concordium/Client/Utils.hs
+++ b/src/Concordium/Client/Utils.hs
@@ -49,7 +49,7 @@ amountFromStringInform :: String -> Either String Amount
 amountFromStringInform s =
   case amountFromString s of
     Just a -> Right a
-    Nothing -> Left $ "Invalid GTU amount '" ++ s ++ "'. Amounts must be of the form n[.m] where m, if present,\n must have at least one and at most 6 digits."
+    Nothing -> Left $ "Invalid CCD amount '" ++ s ++ "'. Amounts must be of the form n[.m] where m, if present,\n must have at least one and at most 6 digits."
 
 
 -- |Try to parse a KeyIndex from a string, and if failing, try to inform the user

--- a/test/SimpleClientTests/AccountSpec.hs
+++ b/test/SimpleClientTests/AccountSpec.hs
@@ -159,7 +159,7 @@ printAccountInfoSpec = describe "printAccountInfo" $ do
   specify "without baker nor credentials" $ p exampleNamedAddress (exampleAccountInfoResult Nothing []) `shouldBe`
     [ "Local names:            'example'"
     , "Address:                2zR4h351M1bqhrL9UywsbHrP3ucA1xY3TBTFRuTsRout8JnLD6"
-    , "Balance:                0.000001 GTU"
+    , "Balance:                0.000001 CCD"
     , "Nonce:                  2"
     , "Encryption public key:  a820662531d0aac70b3a80dd8a249aa692436097d06da005aec7c56aad17997ec8331d1e4050fd8dced2b92f06277bd5aae71cf315a6d70c849508f6361ac6d51c2168305dd1604c4c6448da4499b2f14afb94fff0f42b79a68ed7ba206301f4"
     , ""
@@ -169,12 +169,12 @@ printAccountInfoSpec = describe "printAccountInfo" $ do
   specify "with baker" $ p exampleNamedAddress (exampleAccountInfoResult (Just NoChange) []) `shouldBe`
     [ "Local names:            'example'"
     , "Address:                2zR4h351M1bqhrL9UywsbHrP3ucA1xY3TBTFRuTsRout8JnLD6"
-    , "Balance:                0.000001 GTU"
+    , "Balance:                0.000001 CCD"
     , "Nonce:                  2"
     , "Encryption public key:  a820662531d0aac70b3a80dd8a249aa692436097d06da005aec7c56aad17997ec8331d1e4050fd8dced2b92f06277bd5aae71cf315a6d70c849508f6361ac6d51c2168305dd1604c4c6448da4499b2f14afb94fff0f42b79a68ed7ba206301f4"
     , ""
     , "Baker: #1"
-    ," - Staked amount: 0.000100 GTU"
+    ," - Staked amount: 0.000100 CCD"
     ," - Restake earnings: yes"
     , ""
     , "Credentials: none" ]
@@ -186,11 +186,11 @@ printAccountInfoSpec = describe "printAccountInfo" $ do
                                                                                                  } }) `shouldBe`
     [ "Local names:            'example'"
     , "Address:                2zR4h351M1bqhrL9UywsbHrP3ucA1xY3TBTFRuTsRout8JnLD6"
-    , "Balance:                0.000001 GTU"
-    , "Release schedule:       total 0.000100 GTU"
-    , "   Tue,  3 Nov 2020 15:28:22 UTC:               0.000033 GTU scheduled by the transactions: f26a45adbb7d5cbefd9430d1eac665bd225fb3d8e04efb288d99a0347f0b8868, b041315fe35a8bdf836647037c24c8e87402547c82aea568c66ee18aa3091326."
-    , "   Tue,  3 Nov 2020 15:29:02 UTC:               0.000033 GTU scheduled by the transactions: f26a45adbb7d5cbefd9430d1eac665bd225fb3d8e04efb288d99a0347f0b8868."
-    , "   Tue,  3 Nov 2020 15:29:42 UTC:               0.000034 GTU scheduled by the transactions: b041315fe35a8bdf836647037c24c8e87402547c82aea568c66ee18aa3091326."
+    , "Balance:                0.000001 CCD"
+    , "Release schedule:       total 0.000100 CCD"
+    , "   Tue,  3 Nov 2020 15:28:22 UTC:               0.000033 CCD scheduled by the transactions: f26a45adbb7d5cbefd9430d1eac665bd225fb3d8e04efb288d99a0347f0b8868, b041315fe35a8bdf836647037c24c8e87402547c82aea568c66ee18aa3091326."
+    , "   Tue,  3 Nov 2020 15:29:02 UTC:               0.000033 CCD scheduled by the transactions: f26a45adbb7d5cbefd9430d1eac665bd225fb3d8e04efb288d99a0347f0b8868."
+    , "   Tue,  3 Nov 2020 15:29:42 UTC:               0.000034 CCD scheduled by the transactions: b041315fe35a8bdf836647037c24c8e87402547c82aea568c66ee18aa3091326."
     , "Nonce:                  2"
     , "Encryption public key:  a820662531d0aac70b3a80dd8a249aa692436097d06da005aec7c56aad17997ec8331d1e4050fd8dced2b92f06277bd5aae71cf315a6d70c849508f6361ac6d51c2168305dd1604c4c6448da4499b2f14afb94fff0f42b79a68ed7ba206301f4"
     , ""
@@ -200,7 +200,7 @@ printAccountInfoSpec = describe "printAccountInfo" $ do
   specify "with one credential" $ p exampleNamedAddress (exampleAccountInfoResult Nothing [exampleCredentials examplePolicyWithoutItems]) `shouldBe`
     [ "Local names:            'example'"
     , "Address:                2zR4h351M1bqhrL9UywsbHrP3ucA1xY3TBTFRuTsRout8JnLD6"
-    , "Balance:                0.000001 GTU"
+    , "Balance:                0.000001 CCD"
     , "Nonce:                  2"
     , "Encryption public key:  a820662531d0aac70b3a80dd8a249aa692436097d06da005aec7c56aad17997ec8331d1e4050fd8dced2b92f06277bd5aae71cf315a6d70c849508f6361ac6d51c2168305dd1604c4c6448da4499b2f14afb94fff0f42b79a68ed7ba206301f4"
     , ""
@@ -216,7 +216,7 @@ printAccountInfoSpec = describe "printAccountInfo" $ do
                                                                                        , exampleCredentials examplePolicyWithTwoItems ]) `shouldBe`
     [ "Local names:            'example'"
     , "Address:                2zR4h351M1bqhrL9UywsbHrP3ucA1xY3TBTFRuTsRout8JnLD6"
-    , "Balance:                0.000001 GTU"
+    , "Balance:                0.000001 CCD"
     , "Nonce:                  2"
     , "Encryption public key:  a820662531d0aac70b3a80dd8a249aa692436097d06da005aec7c56aad17997ec8331d1e4050fd8dced2b92f06277bd5aae71cf315a6d70c849508f6361ac6d51c2168305dd1604c4c6448da4499b2f14afb94fff0f42b79a68ed7ba206301f4"
     , ""
@@ -237,7 +237,7 @@ printAccountInfoSpec = describe "printAccountInfo" $ do
     (execWriter $ printAccountInfo exampleTime exampleNamedAddress (exampleAccountInfoResult Nothing [exampleCredentials examplePolicyWithoutItems]) True False Nothing) `shouldBe`
       [ "Local names:            'example'"
       , "Address:                2zR4h351M1bqhrL9UywsbHrP3ucA1xY3TBTFRuTsRout8JnLD6"
-      , "Balance:                0.000001 GTU"
+      , "Balance:                0.000001 CCD"
       , "Nonce:                  2"
       , "Encryption public key:  a820662531d0aac70b3a80dd8a249aa692436097d06da005aec7c56aad17997ec8331d1e4050fd8dced2b92f06277bd5aae71cf315a6d70c849508f6361ac6d51c2168305dd1604c4c6448da4499b2f14afb94fff0f42b79a68ed7ba206301f4"
       , ""
@@ -266,7 +266,7 @@ printAccountInfoSpec = describe "printAccountInfo" $ do
   specify "show encrypted balance" $ penc exampleNamedAddress (exampleAccountInfoResult Nothing [exampleCredentials examplePolicyWithoutItems]) `shouldBe`
     [ "Local names:            'example'"
     , "Address:                2zR4h351M1bqhrL9UywsbHrP3ucA1xY3TBTFRuTsRout8JnLD6"
-    , "Balance:                0.000001 GTU"
+    , "Balance:                0.000001 CCD"
     , "Nonce:                  2"
     , "Encryption public key:  a820662531d0aac70b3a80dd8a249aa692436097d06da005aec7c56aad17997ec8331d1e4050fd8dced2b92f06277bd5aae71cf315a6d70c849508f6361ac6d51c2168305dd1604c4c6448da4499b2f14afb94fff0f42b79a68ed7ba206301f4"
     , ""
@@ -288,7 +288,7 @@ printAccountInfoSpec = describe "printAccountInfo" $ do
     (execWriter $ printAccountInfo exampleTime exampleNamedAddress (exampleAccountInfoResult Nothing [exampleCredentials examplePolicyWithoutItems]) True True Nothing) `shouldBe`
       [ "Local names:            'example'"
       , "Address:                2zR4h351M1bqhrL9UywsbHrP3ucA1xY3TBTFRuTsRout8JnLD6"
-      , "Balance:                0.000001 GTU"
+      , "Balance:                0.000001 CCD"
       , "Nonce:                  2"
       , "Encryption public key:  a820662531d0aac70b3a80dd8a249aa692436097d06da005aec7c56aad17997ec8331d1e4050fd8dced2b92f06277bd5aae71cf315a6d70c849508f6361ac6d51c2168305dd1604c4c6448da4499b2f14afb94fff0f42b79a68ed7ba206301f4"
       , ""

--- a/test/SimpleClientTests/TransactionSpec.hs
+++ b/test/SimpleClientTests/TransactionSpec.hs
@@ -215,46 +215,46 @@ printTransactionStatusTests = describe "print transaction status" $ do
   describe "committed into one block with status 'success'" $
     specify "correct output" $
       p committedOneSuccessfulOutcome `shouldBe`
-        [ "Transaction is committed into block 0a5d64f644461d95315a781475b83f723f74d1c21542bd4f3e234d6173374389 with status \"success\" and cost 0.000010 GTU (10 NRG)." ]
+        [ "Transaction is committed into block 0a5d64f644461d95315a781475b83f723f74d1c21542bd4f3e234d6173374389 with status \"success\" and cost 0.000010 CCD (10 NRG)." ]
   describe "committed into one block with status 'rejected'" $
     specify "correct output" $
       p committedOneFailedOutcome `shouldBe`
-        [ "Transaction is committed into block be880f81dfbcc0a049c3defe483327d0a2a3002a186a06d34bcd93a9be7f9994 with status \"rejected\" and cost 0.000020 GTU (20 NRG)."
+        [ "Transaction is committed into block be880f81dfbcc0a049c3defe483327d0a2a3002a186a06d34bcd93a9be7f9994 with status \"rejected\" and cost 0.000020 CCD (20 NRG)."
         , "Transaction rejected: insufficient funds." ]
   describe "committed into two blocks with same (successful) outcome" $
     specify "correct output" $
       p committedTwoIdenticalSuccessfulOutcomes `shouldBe`
-        [ "Transaction is committed into 2 blocks with status \"success\" and cost 0.000010 GTU (10 NRG):"
+        [ "Transaction is committed into 2 blocks with status \"success\" and cost 0.000010 CCD (10 NRG):"
         , "- 0a5d64f644461d95315a781475b83f723f74d1c21542bd4f3e234d6173374389"
         , "- 0f71eeca9f0a497dc4427cab0544f2bcb820b328ad97be29181e212edea708fd" ]
   describe "committed into two blocks with different (successful) outcomes" $
     specify "correct output" $
       p committedTwoDifferentSuccessfulOutcomes `shouldBe`
         [ "Transaction is committed into 2 blocks:"
-        , "- 0a5d64f644461d95315a781475b83f723f74d1c21542bd4f3e234d6173374389 with status \"success\" and cost 0.000010 GTU (10 NRG):"
+        , "- 0a5d64f644461d95315a781475b83f723f74d1c21542bd4f3e234d6173374389 with status \"success\" and cost 0.000010 CCD (10 NRG):"
         , "  * transferred 10 tokens from account '2zR4h351M1bqhrL9UywsbHrP3ucA1xY3TBTFRuTsRout8JnLD6' to account '4MkK65HrYvMauNTHTuL23wRDKp4VXkCiTpmoWYFtsrZHV3WwSa'"
-        , "- 941c24374cd077de2120fb58732306c3115a08bb7b7cda120a04fecc412b1795 with status \"success\" and cost 0.000020 GTU (20 NRG):"
+        , "- 941c24374cd077de2120fb58732306c3115a08bb7b7cda120a04fecc412b1795 with status \"success\" and cost 0.000020 CCD (20 NRG):"
         , "  * transferred 10 tokens from account '2zR4h351M1bqhrL9UywsbHrP3ucA1xY3TBTFRuTsRout8JnLD6' to account '4MkK65HrYvMauNTHTuL23wRDKp4VXkCiTpmoWYFtsrZHV3WwSa'" ]
   describe "committed into two blocks" $
     specify "correct output" $
       p committedSuccessfulAndFailureOutcomes `shouldBe`
         [ "Transaction is committed into 2 blocks:"
-        , "- 0a5d64f644461d95315a781475b83f723f74d1c21542bd4f3e234d6173374389 with status \"success\" and cost 0.000010 GTU (10 NRG):"
+        , "- 0a5d64f644461d95315a781475b83f723f74d1c21542bd4f3e234d6173374389 with status \"success\" and cost 0.000010 CCD (10 NRG):"
         , "  * transferred 10 tokens from account '2zR4h351M1bqhrL9UywsbHrP3ucA1xY3TBTFRuTsRout8JnLD6' to account '4MkK65HrYvMauNTHTuL23wRDKp4VXkCiTpmoWYFtsrZHV3WwSa'"
-        , "- be880f81dfbcc0a049c3defe483327d0a2a3002a186a06d34bcd93a9be7f9994 with status \"rejected\" and cost 0.000020 GTU (20 NRG):"
+        , "- be880f81dfbcc0a049c3defe483327d0a2a3002a186a06d34bcd93a9be7f9994 with status \"rejected\" and cost 0.000020 CCD (20 NRG):"
         , "  * account or contract '2zR4h351M1bqhrL9UywsbHrP3ucA1xY3TBTFRuTsRout8JnLD6' does not have enough funds to transfer 11 tokens"]
   describe "committed into two blocks" $
     specify "correct output" $
       p committedSuccessfulAndFailureOutcomes `shouldBe`
         [ "Transaction is committed into 2 blocks:"
-        , "- 0a5d64f644461d95315a781475b83f723f74d1c21542bd4f3e234d6173374389 with status \"success\" and cost 0.000010 GTU (10 NRG):"
+        , "- 0a5d64f644461d95315a781475b83f723f74d1c21542bd4f3e234d6173374389 with status \"success\" and cost 0.000010 CCD (10 NRG):"
         , "  * transferred 10 tokens from account '2zR4h351M1bqhrL9UywsbHrP3ucA1xY3TBTFRuTsRout8JnLD6' to account '4MkK65HrYvMauNTHTuL23wRDKp4VXkCiTpmoWYFtsrZHV3WwSa'"
-        , "- be880f81dfbcc0a049c3defe483327d0a2a3002a186a06d34bcd93a9be7f9994 with status \"rejected\" and cost 0.000020 GTU (20 NRG):"
+        , "- be880f81dfbcc0a049c3defe483327d0a2a3002a186a06d34bcd93a9be7f9994 with status \"rejected\" and cost 0.000020 CCD (20 NRG):"
         , "  * account or contract '2zR4h351M1bqhrL9UywsbHrP3ucA1xY3TBTFRuTsRout8JnLD6' does not have enough funds to transfer 11 tokens" ]
   describe "finalized with single outcome" $
     specify "correct output" $
       p finalized `shouldBe`
-        [ "Transaction is finalized into block 0a5d64f644461d95315a781475b83f723f74d1c21542bd4f3e234d6173374389 with status \"success\" and cost 0.000010 GTU (10 NRG)." ]
+        [ "Transaction is finalized into block 0a5d64f644461d95315a781475b83f723f74d1c21542bd4f3e234d6173374389 with status \"success\" and cost 0.000010 CCD (10 NRG)." ]
   -- Unexpected cases.
   describe "committed with no outcomes" $
     specify "correct output" $


### PR DESCRIPTION
## Purpose

Changes following the renaming of GTU token to CCD.

## Changes

- rename GTU token to CCD
- rename send-gtu, send-gtu-scheduled and send-gtu-encrypted to send,
  send-scheduled and send-shielded.

## Checklist

- [ ] My code follows the style of this project.
- [ ] The code compiles without warnings.
- [ ] I have performed a self-review of the changes.
- [ ] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [ ] (If necessary) I have updated the CHANGELOG.
