### PR TITLE
Remove the threaded option from tx-generator

### DIFF
--- a/concordium-client.cabal
+++ b/concordium-client.cabal
@@ -212,7 +212,7 @@ executable tx-generator
       FlexibleContexts
       LambdaCase
       TupleSections
-  ghc-options: -Wall -Wcompat -Werror=missing-fields -Wredundant-constraints -O -threaded
+  ghc-options: -Wall -Wcompat -Werror=missing-fields -Wredundant-constraints -O
   build-depends:
       aeson
     , base

--- a/package.yaml
+++ b/package.yaml
@@ -133,7 +133,6 @@ executables:
       - -Werror=missing-fields
       - -Wredundant-constraints
       - -O
-      - -threaded
 
     when:
       - condition: flag(static)


### PR DESCRIPTION
## Purpose

The tx-generator tool deadlocks on windows when compiled with -threaded

## Changes

Removed the threaded flag.

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
