### PR TITLE
Adds calling fallback entry point feature to `concordium-client`

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -10,6 +10,8 @@
     prefix.
 - `contract update` command now uses `--entrypoint` to specify the function to
   invoke. This is renamed from the previous `--func`.
+- When calling `contract update` or `contract invoke` with a non-existent
+  entrypoint the fallback entrypoint is called if one specified in the contract.
 
 ## 3.0.4
 - Rename `--encrypted` and `--decrypt-encrypted` flags to `account show` to

--- a/src/Concordium/Client/Output.hs
+++ b/src/Concordium/Client/Output.hs
@@ -634,12 +634,12 @@ showRejectReason verbose = \case
       "account does not exist"
   Types.InvalidInitMethod m name ->
     if verbose then
-      printf "invalid init method '%s' of module '%s'" (show name) (show m)
+      [i|invalid init method '#{name}' of module '#{m}'|]
     else
       "invalid init method"
   Types.InvalidReceiveMethod m name ->
     if verbose then
-      printf "invalid receive method '%s' of module '%s'" (show name) (show m)
+      [i|invalid receive method '#{name}' of module '#{m}'|]
     else
       "invalid receive method"
   Types.InvalidModuleReference m ->

--- a/src/Concordium/Client/Runner.hs
+++ b/src/Concordium/Client/Runner.hs
@@ -1848,7 +1848,7 @@ data ModuleDeployTransactionCfg =
 moduleDeployTransactionPayload :: ModuleDeployTransactionCfg -> Types.Payload
 moduleDeployTransactionPayload ModuleDeployTransactionCfg {..} = Types.DeployModule mdtcModule
 
--- |Checks if the he given receive name is valid and if so, returns it back
+-- |Checks if the given receive name is valid and if so, returns it back
 -- or otherwise a fallback receive name for v1 contracts.
 checkAndGetContractReceiveName :: CI.ContractInfo -> Text -> IO Text
 checkAndGetContractReceiveName contrInfo receiveName = do

--- a/src/Concordium/Client/Runner.hs
+++ b/src/Concordium/Client/Runner.hs
@@ -2143,11 +2143,11 @@ getContractUpdateTransactionCfg backend baseCfg txOpts indexOrName subindex rece
   txCfg <- getRequiredEnergyTransactionCfg baseCfg txOpts
   namedContrAddr <- getNamedContractAddress (bcContractNameMap baseCfg) indexOrName subindex
   contrInfo <- withClient backend . withBestBlockHash Nothing $ getContractInfo namedContrAddr
-  _ <- checkAndGetContractReceiveName contrInfo receiveName
+  updatedReceiveName <- checkAndGetContractReceiveName contrInfo receiveName
   let namedModRef = NamedModuleRef {nmrRef = CI.ciSourceModule contrInfo, nmrNames = []}
   let contrName = CI.getContractName contrInfo
   schema <- withClient backend . withBestBlockHash Nothing $ getSchemaFromFileOrModule schemaFile namedModRef
-  params <- getWasmParameter paramsFile schema (CS.ReceiveFuncName contrName receiveName)
+  params <- getWasmParameter paramsFile schema (CS.ReceiveFuncName contrName updatedReceiveName)
   return $ ContractUpdateTransactionCfg txCfg (ncaAddr namedContrAddr)
            contrName (Wasm.ReceiveName [i|#{contrName}.#{receiveName}|]) params amount
 

--- a/src/Concordium/Client/Types/Contract/Info.hs
+++ b/src/Concordium/Client/Types/Contract/Info.hs
@@ -133,7 +133,7 @@ getContractName = \case
   ContractInfoV1{..} -> ciName
 
 -- |Returns True if the contract has fallback entrypoint support,
--- False otherwise
+-- False otherwise.
 hasFallbackReceiveSupport :: ContractInfo -> Bool
 hasFallbackReceiveSupport = \case
   ContractInfoV0{} -> False

--- a/src/Concordium/Client/Types/Contract/Info.hs
+++ b/src/Concordium/Client/Types/Contract/Info.hs
@@ -3,6 +3,7 @@ module Concordium.Client.Types.Contract.Info
   ( contractNameFromInitName
   , addSchemaData
   , getContractName
+  , hasFallbackReceiveSupport
   , hasReceiveMethod
   , constructModuleInspectInfo
   , ContractInfo(..)
@@ -130,6 +131,13 @@ getContractName :: ContractInfo -> Text
 getContractName = \case
   ContractInfoV0{..} -> ciName
   ContractInfoV1{..} -> ciName
+
+-- |Returns True if the contract has fallback entrypoint support,
+-- False otherwise
+hasFallbackReceiveSupport :: ContractInfo -> Bool
+hasFallbackReceiveSupport = \case
+  ContractInfoV0{} -> False
+  ContractInfoV1{} -> True
 
 -- |This is returned by the node and specified in Concordium.Getters (from prototype repo).
 -- Must stay in sync.


### PR DESCRIPTION
## Purpose

When calling `contract update` with an invalid entrypoint
the fallback entrypoint is called if one specified in the contract.

The name of the fallback entrypoint is assumed to be an empty string.

## Changes

Checks the existence of specified and default entrypoint names.

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [x] (If necessary) I have updated the CHANGELOG.
