### PR TITLE
Fix payload size calculation.

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,6 +1,9 @@
 # Changelog for concordium-client
 
 ## Unreleased
+- Fix calculation of payload size of a configure baker transaction in
+  the function `bakerConfigurePayloadSize` in Transactions.hs used by
+  the wallet-proxy.
 
 ## 4.0.2
 - Add support for v1 smart contracts.

--- a/src/Concordium/Client/Types/Transaction.hs
+++ b/src/Concordium/Client/Types/Transaction.hs
@@ -108,7 +108,7 @@ bakerConfigurePayloadSize hasCapital hasRestake hasPoolOpen hasKeys mMetadata ha
   + (if hasRestake then 1 else 0)
   + (if hasPoolOpen then 1 else 0)
   + (if hasKeys then fromIntegral bakerKeysWithProofsSize else 0)
-  + maybe 0 fromIntegral mMetadata
+  + maybe 0 ((+2) . fromIntegral) mMetadata
   + (if hasTCom then 4 else 0)
   + (if hasBCom then 4 else 0)
   + (if hasFCom then 4 else 0)


### PR DESCRIPTION
## Purpose

To fix the payload size calculation of a configure baker transaction. If the metadata url is set/updated, the size was of off by 2. Closes #135. 

## Changes

* The calculation has been corrected.

## Checklist

- [ ] My code follows the style of this project.
- [ ] The code compiles without warnings.
- [ ] I have performed a self-review of the changes.
- [ ] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [ ] (If necessary) I have updated the CHANGELOG.

