### PR TITLE
Fix baker removed printf bug

### DIFF
--- a/src/Concordium/Client/Output.hs
+++ b/src/Concordium/Client/Output.hs
@@ -573,7 +573,7 @@ showEvent verbose = \case
     let restakeString :: String = if ebaRestakeEarnings then "Earnings are added to the stake." else "Earnings are not added to the stake."
     in verboseOrNothing $ printf "baker %s added, staking %s CCD. %s" (showBaker ebaBakerId ebaAccount) (Types.amountToString ebaStake) restakeString
   Types.BakerRemoved{..} ->
-    verboseOrNothing $ printf "baker %s, removed" (showBaker ebrBakerId ebrAccount) (show ebrBakerId)
+    verboseOrNothing $ printf "baker %s, removed" (showBaker ebrBakerId ebrAccount)
   Types.BakerStakeIncreased{..} ->
     verboseOrNothing $ printf "baker %s stake increased to %s" (showBaker ebsiBakerId ebsiAccount) (Types.amountToString ebsiNewStake)
   Types.BakerStakeDecreased{..} ->


### PR DESCRIPTION
## Purpose

Fixes a small bug that appears when you query a transaction that removes a baker:

```
❯ concordium-client transaction status 23da931b964c95e63152e941f5bd0ae722dcd093e98a236e42e5130772148fab
Transaction is finalized into block fba0869f4d0bcb4f3e430a5dabe3595032530beb123d724cf52bf9af0280e596 with status "success" and cost 0.451155 CCD (471 NRG).
baker 2zMNm3Pz24k3si5Z8pf4aXYPr6FzcUKDgo6WaFhKzYz9j3nnrk (ID 471), removedconcordium-client: printf: formatting string ended prematurely
```

Notice the: `concordium-client: printf: formatting string ended prematurely`

## Changes

- Remove extraneous argument to printf

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [ ] (If necessary) I have updated the CHANGELOG.