### PR TITLE
Support importing the browser extension wallet import format.

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -4,6 +4,7 @@
 
 - Fix handling of `--no-confirm` in `contract init`, `contract update`, `module
   deploy`, and `register data` transactions. This flag is now respected.
+- Add support for importing accounts exported by the browser extension wallet.
 
 ## 4.1.0
 

--- a/src/Concordium/Client/Commands.hs
+++ b/src/Concordium/Client/Commands.hs
@@ -1191,7 +1191,7 @@ configAccountImportCmd showAllOpts =
     "import"
     (info
       (ConfigAccountImport <$>
-        strArgument (metavar "FILE" <> help "Account file exported from the wallet. By default all accounts will be imported.") <*>
+        strArgument (metavar "FILE" <> help "File with one or more accounts exported from the wallet.") <*>
         optional (strOption (long "name" <> metavar "NAME" <> help nameOptionHelp)) <*>
         option readAccountExportFormat (internalUnless showAllOpts <> long "format" <> metavar "FORMAT" <> value FormatMobile <> help "Export format. Supported values are 'mobile' and 'genesis' (default: 'mobile').") <*>
         switch (long "skip-existing" <> short 's' <> help "Automatically skip importing accounts when the keydirectory already exists")

--- a/src/Concordium/Client/Export.hs
+++ b/src/Concordium/Client/Export.hs
@@ -75,23 +75,53 @@ data WalletExport =
   }
   deriving (Show)
 
-instance AE.FromJSON WalletExport where
-  parseJSON = AE.withObject "Wallet Export" $ \v -> do
+-- |Parse export from the wallet. The data that is exported depends a bit on
+-- which wallet it is, so the parser requires some context which is why this is
+-- a separate function, and not a @FromJSON@ instance.
+parseWalletExport ::
+  -- |The name of the account to import. The old mobile wallet export does not
+  -- require this, but for the new mobile wallet export it is required, and parsing
+  -- will fail if this is not provided.
+  Maybe Text ->
+  -- |The JSON value to be parsed.
+  AE.Value ->
+  AE.Parser WalletExport
+parseWalletExport mName = AE.withObject "Wallet Export" $ \v -> do
     -- Validate type and version.
     t <- v .: "type"
-    version <- v .: "v"
-    unless (t == "concordium-mobile-wallet-data") $
-      fail $ printf "unsupported type '%s'" (t :: String)
-    unless (version == 1) $
-      fail $ printf "unsupported version '%s'" (version :: Int)
-    val <- v .: "value"
-    ids <- val .: "identities"
-    -- We are trying to be explicit about the reason for failure here since the older format
-    -- did not have the environment field, and we want the error message to be better than "missing field".
-    wepEnvironment <- v .:? "environment" >>= \case
-      Nothing -> fail "Missing 'environment' field. Most likely this means the export file was produced by an older, unsupported, wallet version."
-      Just env -> return env
-    return WalletExport { wepAccounts = weiAccounts =<< ids, .. }
+    case t of
+      "concordium-mobile-wallet-data" -> do
+        version <- v .: "v"
+        unless (version == 1) $
+          fail $ printf "unsupported mobile wallet export version '%s'" (version :: Int)
+        val <- v .: "value"
+        ids <- val .: "identities"
+        -- We are trying to be explicit about the reason for failure here since the older format
+        -- did not have the environment field, and we want the error message to be better than "missing field".
+        wepEnvironment <- v .:? "environment" >>= \case
+          Nothing -> fail "Missing 'environment' field. Most likely this means the export file was produced by an older, unsupported, wallet version."
+          Just env -> return env
+        return WalletExport { wepAccounts = weiAccounts =<< ids, .. }
+
+      "concordium-browser-wallet-account" -> do
+        weaName <- case mName of
+          Nothing -> fail "To import an account from the browser wallet you have to provide a name using the `--name` option."
+          Just n -> return n
+        version <- v .: "v"
+        unless (version == 0) $
+          fail $ printf "unsupported browser extension export version '%s'" (version :: Int)
+        val <- v .: "value"
+        wepEnvironment <- v .: "environment"
+        keys <- val .: "accountKeys"
+        asdKeys <- mapM parseCredKeys =<< (keys .: "keys")
+        asdThreshold <- keys .: "threshold"
+        weaCredMap <- val .: "credentials"
+        asdAddress <- val .: "address"
+        let weaKeys = AccountSigningData{..}
+        return WalletExport { wepAccounts = [WalletExportAccount{weaEncryptionKey = Nothing, ..}], .. }
+      other -> fail $ printf "unsupported type '%s'" (other :: String)
+
+      where parseCredKeys = AE.withObject "Credential keys" (.: "keys")
 
 -- | Used for parsing 'WalletExport'.
 newtype WalletExportIdentity =
@@ -109,7 +139,7 @@ data WalletExportAccount =
   { weaName :: !Text
   , weaKeys :: !AccountSigningData
   , weaCredMap :: !(OrdMap.Map IDTypes.CredentialIndex IDTypes.CredentialRegistrationID)
-  , weaEncryptionKey :: !ElgamalSecretKey }
+  , weaEncryptionKey :: !(Maybe ElgamalSecretKey) }
   deriving (Show)
 
 instance AE.FromJSON WalletExportAccount where
@@ -141,12 +171,21 @@ decodeMobileFormattedAccountExport
   :: BS.ByteString -- ^ JSON with encrypted accounts and identities,
                    -- which must include the fields of an 'EncryptedJSON WalletExport'.
   -> Maybe Text -- ^ Only return the account with the given name (if it exists, otherwise return none).
-  -> Password -- ^ Password to decrypt the export and to encrypt the sign keys.
+  -> IO Password -- ^ Action to ask for password to decrypt the export or to encrypt the sign keys.
   -> IO (Either String ([AccountConfig], Environment)) -- ^ A list of resulting 'AccountConfig's and their environment, or an error message on failure.
-decodeMobileFormattedAccountExport json accountName password = runExceptT $ do
-  we :: EncryptedJSON WalletExport <- AE.eitherDecodeStrict json `embedErr` printf "cannot decode wallet export JSON: %s"
-  WalletExport{..} <- decryptJSON we password `embedErr` (("cannot decrypt wallet export: " ++) . displayException)
-  (, wepEnvironment) <$> accountCfgsFromWalletExportAccounts wepAccounts accountName password
+decodeMobileFormattedAccountExport jsonBS accountName passwordAct = runExceptT $ do
+  jsonValue <- AE.eitherDecodeStrict jsonBS `embedErr` printf "cannot decode wallet export: %s"
+  if isLikelyEncrypted jsonValue then do
+    we :: EncryptedJSON WalletExport <- AE.eitherDecodeStrict jsonBS `embedErr` printf "cannot decode wallet export JSON: %s"
+    password <- liftIO passwordAct
+    WalletExport{..} <- decryptJSONWith we password (parseWalletExport accountName) `embedErr` (("cannot decrypt wallet export: " ++) . displayException)
+    (, wepEnvironment) <$> accountCfgsFromWalletExportAccounts wepAccounts accountName password
+  else do
+    case AE.parseEither (parseWalletExport accountName) jsonValue of
+      Left err -> throwError [i|Cannot decode wallet export: #{err}|]
+      Right WalletExport{..} -> do
+          password <- liftIO passwordAct
+          (, wepEnvironment) <$> accountCfgsFromWalletExportAccounts wepAccounts accountName password
 
 -- | Convert one or all wallet export accounts to regular account configs.
 -- This encrypts all signing keys with the provided password.
@@ -170,7 +209,9 @@ accountCfgFromWalletExportAccount :: Password -> WalletExportAccount -> ExceptT 
 accountCfgFromWalletExportAccount pwd WalletExportAccount { weaKeys = AccountSigningData{..}, .. } = do
   name <- liftIO $ ensureValidName weaName
   acKeys <- liftIO $ encryptAccountKeyMap pwd asdKeys
-  acEncryptionKey <- Just <$> (liftIO $ encryptAccountEncryptionSecretKey pwd weaEncryptionKey)
+  acEncryptionKey <- case weaEncryptionKey of
+    Nothing -> return Nothing
+    Just ek -> liftIO . fmap Just $ encryptAccountEncryptionSecretKey pwd ek
   return $ AccountConfig
     { acAddr = NamedAddress { naNames = [name], naAddr = asdAddress }
     , acCids = weaCredMap

--- a/src/Concordium/Client/Runner.hs
+++ b/src/Concordium/Client/Runner.hs
@@ -497,7 +497,7 @@ loadAccountImportFile format file name = do
   contents <- handleReadFile BS.readFile file
   case format of
     FormatMobile -> do
-      pwd <- askPassword "Enter encryption password: "
+      let pwd = askPassword "Enter encryption password: "
       (accCfgs, environment) <- decodeMobileFormattedAccountExport contents name pwd `withLogFatalIO` ("cannot import accounts: " ++)
       let accountsMessage :: Text = if length accCfgs >= 2 then "accounts" else "account"
       logInfo [[i|loaded the following #{accountsMessage} from the #{environment} chain:|]]

--- a/src/Concordium/Client/Types/Account.hs
+++ b/src/Concordium/Client/Types/Account.hs
@@ -10,8 +10,10 @@ import Control.Monad
 import Control.Monad.Except
 import Control.Exception
 
+import qualified Data.List as List
 import qualified Data.Map.Strict as Map
 import Data.Text (Text)
+import qualified Data.Text as Text
 import qualified Data.Aeson as AE
 import Data.Aeson ((.=),(.:),(.:?), (.!=))
 
@@ -30,7 +32,14 @@ import Data.ByteString (ByteString)
 -- * Accounts
 
 data NamedAddress = NamedAddress { naNames :: [Text], naAddr :: ID.AccountAddress }
-  deriving (Show, Eq)
+  deriving (Eq)
+
+-- The Show instance of NamedAddress is used in some error reporting, so we try
+-- to make it reasonably nice.
+instance Show NamedAddress where
+  show NamedAddress{..} = show naAddr ++ showNames
+      where showNames | List.null naNames = ""
+                      | otherwise = " (" ++ (List.intercalate ", " . map (\n -> "'" ++ Text.unpack n ++ "'") $ naNames) ++ ")"
 
 instance AE.ToJSON NamedAddress where
   toJSON (NamedAddress naNames naAddr) = AE.object ["names" .= naNames, "address" .= naAddr]


### PR DESCRIPTION
## Purpose

Closes #170 

## Changes

Revise the mobile wallet import function to handle the new format. The new format only has one account, and does not supply the account encryption key. If such an account is imported then it will not be usable for actions that require it, such as decrypting the balance. If a user attempts this they will be met with

- [x] Depends on https://github.com/Concordium/concordium-base/pull/224

```
Error: Missing account encryption secret key for account: 3FS3Bfmds6Qj5dXHEGnzJcN8yNzfr5FqwF1qobTwYso2XxmGz2 ('account_name').
```

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [x] (If necessary) I have updated the CHANGELOG.