### PR TITLE
Make the output of transaction outcomes consistently use "x.y CCD" fo…

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -5,6 +5,8 @@
 - Fix handling of `--no-confirm` in `contract init`, `contract update`, `module
   deploy`, and `register data` transactions. This flag is now respected.
 - Add support for importing accounts exported by the browser extension wallet.
+- Make the output of CCD amounts consistent when printing transaction outcomes.
+  The output should now always `x.y CCD` for some `x` and `y`.
 
 ## 4.1.0
 

--- a/src/Concordium/Client/Output.hs
+++ b/src/Concordium/Client/Output.hs
@@ -596,13 +596,13 @@ showEvent verbose = \case
   Types.ModuleDeployed ref->
     verboseOrNothing $ printf "module '%s' deployed" (show ref)
   Types.ContractInitialized{..} ->
-    verboseOrNothing $ printf "initialized contract '%s' using init function '%s' from module '%s' with '%s' tokens"
-                              (show ecAddress) (show ecInitName) (show ecRef) (show ecAmount)
+    verboseOrNothing $ printf "initialized contract '%s' using init function '%s' from module '%s' with %s"
+                              (show ecAddress) (show ecInitName) (show ecRef) (showCcd ecAmount)
   Types.Updated{..} ->
-    verboseOrNothing $ printf "sent message to function '%s' with '%s' and '%s' tokens from %s to %s"
-                              (show euReceiveName) (show euMessage) (show euAmount) (showAddress euInstigator) (showAddress $ Types.AddressContract euAddress)
+    verboseOrNothing $ printf "sent message to function '%s' with '%s' and %s from %s to %s"
+                              (show euReceiveName) (show euMessage) (showCcd euAmount) (showAddress euInstigator) (showAddress $ Types.AddressContract euAddress)
   Types.Transferred{..} ->
-    verboseOrNothing $ printf "transferred %s tokens from %s to %s" (show etAmount) (showAddress etFrom) (showAddress etTo)
+    verboseOrNothing $ printf "transferred %s from %s to %s" (showCcd etAmount) (showAddress etFrom) (showAddress etTo)
   Types.AccountCreated addr ->
     verboseOrNothing $ printf "account '%s' created" (show addr)
   Types.CredentialDeployed{..} ->
@@ -613,9 +613,9 @@ showEvent verbose = \case
   Types.BakerRemoved{..} ->
     verboseOrNothing $ printf "baker %s, removed" (showBaker ebrBakerId ebrAccount)
   Types.BakerStakeIncreased{..} ->
-    verboseOrNothing $ printf "baker %s stake increased to %s" (showBaker ebsiBakerId ebsiAccount) (Types.amountToString ebsiNewStake)
+    verboseOrNothing $ printf "baker %s stake increased to %s" (showBaker ebsiBakerId ebsiAccount) (showCcd ebsiNewStake)
   Types.BakerStakeDecreased{..} ->
-    verboseOrNothing $ printf "baker %s stake decreased to %s" (showBaker ebsiBakerId ebsiAccount) (Types.amountToString ebsiNewStake)
+    verboseOrNothing $ printf "baker %s stake decreased to %s" (showBaker ebsiBakerId ebsiAccount) (showCcd ebsiNewStake)
   Types.BakerSetRestakeEarnings{..} ->
     verboseOrNothing $ printf "baker %s restake earnings %s" (showBaker ebsreBakerId ebsreAccount) (if ebsreRestakeEarnings then "set" :: String else "unset")
   Types.BakerKeysUpdated{..} ->
@@ -633,9 +633,9 @@ showEvent verbose = \case
   Types.BakerSetFinalizationRewardCommission{..} ->
     verboseOrNothing $ printf "baker %s changed finalization reward commission to %s" (showBaker ebsfrcBakerId ebsfrcAccount) (show ebsfrcFinalizationRewardCommission)
   Types.DelegationStakeIncreased{..} ->
-    verboseOrNothing $ printf "delegator %s stake increased to %s" (showDelegator edsiDelegatorId edsiAccount) (Types.amountToString edsiNewStake)
+    verboseOrNothing $ printf "delegator %s stake increased to %s" (showDelegator edsiDelegatorId edsiAccount) (showCcd edsiNewStake)
   Types.DelegationStakeDecreased{..} ->
-    verboseOrNothing $ printf "delegator %s stake decreased to %s" (showDelegator edsdDelegatorId edsdAccount) (Types.amountToString edsdNewStake)
+    verboseOrNothing $ printf "delegator %s stake decreased to %s" (showDelegator edsdDelegatorId edsdAccount) (showCcd edsdNewStake)
   Types.DelegationSetRestakeEarnings{..} ->
     verboseOrNothing $ printf "delegator %s restake earnings changed to %s" (showDelegator edsreDelegatorId edsreAccount) (show edsreRestakeEarnings)
   Types.DelegationSetDelegationTarget{..} ->
@@ -648,8 +648,8 @@ showEvent verbose = \case
   Types.CredentialKeysUpdated cid -> verboseOrNothing $ printf "credential keys updated for credential with credId %s" (show cid)
   Types.NewEncryptedAmount{..} -> verboseOrNothing $ printf "shielded amount received on account '%s' with index '%s'" (show neaAccount) (show neaNewIndex)
   Types.EncryptedAmountsRemoved{..} -> verboseOrNothing $ printf "shielded amounts removed on account '%s' up to index '%s' with a resulting self shielded amount of '%s'" (show earAccount) (show earUpToIndex) (show earNewAmount)
-  Types.AmountAddedByDecryption{..} -> verboseOrNothing $ printf "transferred '%s' tokens from the shielded balance to the public balance on account '%s'" (show aabdAmount) (show aabdAccount)
-  Types.EncryptedSelfAmountAdded{..} -> verboseOrNothing $ printf "transferred '%s' tokens from the public balance to the shielded balance on account '%s' with a resulting self shielded balance of '%s'" (show eaaAmount) (show eaaAccount) (show eaaNewAmount)
+  Types.AmountAddedByDecryption{..} -> verboseOrNothing $ printf "transferred %s from the shielded balance to the public balance on account '%s'" (showCcd aabdAmount) (show aabdAccount)
+  Types.EncryptedSelfAmountAdded{..} -> verboseOrNothing $ printf "transferred %s from the public balance to the shielded balance on account '%s' with a resulting self shielded balance of '%s'" (showCcd eaaAmount) (show eaaAccount) (show eaaNewAmount)
   Types.UpdateEnqueued{..} ->
     verboseOrNothing $ printf "Enqueued chain update, effective at %s:\n%s" (showTimeFormatted (timeFromTransactionExpiryTime ueEffectiveTime)) (show uePayload)
   Types.TransferredWithSchedule{..} ->
@@ -745,7 +745,7 @@ showRejectReason verbose = \case
     "runtime failure"
   Types.AmountTooLarge a amount ->
     if verbose then
-      printf "account or contract '%s' does not have enough funds to transfer %s tokens" (show a) (show amount)
+      printf "account or contract '%s' does not have enough funds to transfer %s" (show a) (showCcd amount)
     else
       "insufficient funds"
   Types.SerializationFailure ->

--- a/test/SimpleClientTests/TransactionSpec.hs
+++ b/test/SimpleClientTests/TransactionSpec.hs
@@ -232,25 +232,25 @@ printTransactionStatusTests = describe "print transaction status" $ do
       p committedTwoDifferentSuccessfulOutcomes `shouldBe`
         [ "Transaction is committed into 2 blocks:"
         , "- 0a5d64f644461d95315a781475b83f723f74d1c21542bd4f3e234d6173374389 with status \"success\" and cost 0.000010 CCD (10 NRG):"
-        , "  * transferred 10 tokens from account '2zR4h351M1bqhrL9UywsbHrP3ucA1xY3TBTFRuTsRout8JnLD6' to account '4MkK65HrYvMauNTHTuL23wRDKp4VXkCiTpmoWYFtsrZHV3WwSa'"
+        , "  * transferred 0.000010 CCD from account '2zR4h351M1bqhrL9UywsbHrP3ucA1xY3TBTFRuTsRout8JnLD6' to account '4MkK65HrYvMauNTHTuL23wRDKp4VXkCiTpmoWYFtsrZHV3WwSa'"
         , "- 941c24374cd077de2120fb58732306c3115a08bb7b7cda120a04fecc412b1795 with status \"success\" and cost 0.000020 CCD (20 NRG):"
-        , "  * transferred 10 tokens from account '2zR4h351M1bqhrL9UywsbHrP3ucA1xY3TBTFRuTsRout8JnLD6' to account '4MkK65HrYvMauNTHTuL23wRDKp4VXkCiTpmoWYFtsrZHV3WwSa'" ]
+        , "  * transferred 0.000010 CCD from account '2zR4h351M1bqhrL9UywsbHrP3ucA1xY3TBTFRuTsRout8JnLD6' to account '4MkK65HrYvMauNTHTuL23wRDKp4VXkCiTpmoWYFtsrZHV3WwSa'" ]
   describe "committed into two blocks" $
     specify "correct output" $
       p committedSuccessfulAndFailureOutcomes `shouldBe`
         [ "Transaction is committed into 2 blocks:"
         , "- 0a5d64f644461d95315a781475b83f723f74d1c21542bd4f3e234d6173374389 with status \"success\" and cost 0.000010 CCD (10 NRG):"
-        , "  * transferred 10 tokens from account '2zR4h351M1bqhrL9UywsbHrP3ucA1xY3TBTFRuTsRout8JnLD6' to account '4MkK65HrYvMauNTHTuL23wRDKp4VXkCiTpmoWYFtsrZHV3WwSa'"
+        , "  * transferred 0.000010 CCD from account '2zR4h351M1bqhrL9UywsbHrP3ucA1xY3TBTFRuTsRout8JnLD6' to account '4MkK65HrYvMauNTHTuL23wRDKp4VXkCiTpmoWYFtsrZHV3WwSa'"
         , "- be880f81dfbcc0a049c3defe483327d0a2a3002a186a06d34bcd93a9be7f9994 with status \"rejected\" and cost 0.000020 CCD (20 NRG):"
-        , "  * account or contract '2zR4h351M1bqhrL9UywsbHrP3ucA1xY3TBTFRuTsRout8JnLD6' does not have enough funds to transfer 11 tokens"]
+        , "  * account or contract '2zR4h351M1bqhrL9UywsbHrP3ucA1xY3TBTFRuTsRout8JnLD6' does not have enough funds to transfer 0.000011 CCD"]
   describe "committed into two blocks" $
     specify "correct output" $
       p committedSuccessfulAndFailureOutcomes `shouldBe`
         [ "Transaction is committed into 2 blocks:"
         , "- 0a5d64f644461d95315a781475b83f723f74d1c21542bd4f3e234d6173374389 with status \"success\" and cost 0.000010 CCD (10 NRG):"
-        , "  * transferred 10 tokens from account '2zR4h351M1bqhrL9UywsbHrP3ucA1xY3TBTFRuTsRout8JnLD6' to account '4MkK65HrYvMauNTHTuL23wRDKp4VXkCiTpmoWYFtsrZHV3WwSa'"
+        , "  * transferred 0.000010 CCD from account '2zR4h351M1bqhrL9UywsbHrP3ucA1xY3TBTFRuTsRout8JnLD6' to account '4MkK65HrYvMauNTHTuL23wRDKp4VXkCiTpmoWYFtsrZHV3WwSa'"
         , "- be880f81dfbcc0a049c3defe483327d0a2a3002a186a06d34bcd93a9be7f9994 with status \"rejected\" and cost 0.000020 CCD (20 NRG):"
-        , "  * account or contract '2zR4h351M1bqhrL9UywsbHrP3ucA1xY3TBTFRuTsRout8JnLD6' does not have enough funds to transfer 11 tokens" ]
+        , "  * account or contract '2zR4h351M1bqhrL9UywsbHrP3ucA1xY3TBTFRuTsRout8JnLD6' does not have enough funds to transfer 0.000011 CCD" ]
   describe "finalized with single outcome" $
     specify "correct output" $
       p finalized `shouldBe`


### PR DESCRIPTION
## Purpose

Fix the output format so that it always talks about "CCD", and not sometimes about tokens, sometimes about CCD, and sometimes in microCCD, sometimes in CCD.

## Changes

- Always use the `showCcd` function.

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [x] (If necessary) I have updated the CHANGELOG.
