### PR TITLE
Add support for using TLS encrypted connection.

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+- Add a `--secure` flag to enable connecting to gRPC using TLS.
+  All commands that query the node support this.
+
 ## 4.2.0
 
 - Fix handling of `--no-confirm` in `contract init`, `contract update`, `module

--- a/middleware/Server.hs
+++ b/middleware/Server.hs
@@ -38,7 +38,7 @@ runHttp middlewares = do
         _ ->
           error $ "Could not parse host:port for given NODE_URL: " ++ T.unpack nodeUrl
 
-    grpcConfig = GrpcConfig { host = nodeHost, port = nodePort, grpcAuthenticationToken = (T.unpack grpcAdminToken), target = Nothing, retryNum = 5, timeout = Nothing }
+    grpcConfig = GrpcConfig { host = nodeHost, port = nodePort, grpcAuthenticationToken = (T.unpack grpcAdminToken), target = Nothing, retryNum = 5, timeout = Nothing, useTls = False }
 
   runExceptT (mkGrpcClient grpcConfig Nothing) >>= \case
     Left err -> fail (show err) -- cannot connect to grpc server

--- a/src/Concordium/Client/Commands.hs
+++ b/src/Concordium/Client/Commands.hs
@@ -66,7 +66,8 @@ data Backend =
     , grpcPort   :: !PortNumber
     , grpcAuthenticationToken :: !String
     , grpcTarget :: !(Maybe String)
-    , grpcRetryNum :: !Int }
+    , grpcRetryNum :: !Int
+    , grpcUseTls :: !Bool }
   deriving (Show)
 
 data Cmd
@@ -520,7 +521,7 @@ versionOption =
   infoOption (showVersion version) (hidden <> long "version" <> help "Show version.")
 
 backendParser :: Parser Backend
-backendParser = GRPC <$> hostParser <*> portParser <*> grpcAuthenticationTokenParser <*> targetParser <*> retryNumParser
+backendParser = GRPC <$> hostParser <*> portParser <*> grpcAuthenticationTokenParser <*> targetParser <*> retryNumParser <*> tlsParser
 
 hostParser :: Parser HostName
 hostParser =
@@ -568,6 +569,12 @@ retryNumParser =
      showDefault <>
      metavar "GRPC-RETRY" <>
      help "How many times to retry the connection if it fails the first time.")
+
+tlsParser :: Parser Bool
+tlsParser =
+  switch
+    (long "secure" <>
+     help "Enable TLS.")
 
 -- |Parse transactionOpts with an optional energy flag
 transactionOptsParser :: Parser (TransactionOpts (Maybe Energy))

--- a/src/Concordium/Client/GRPC.hs
+++ b/src/Concordium/Client/GRPC.hs
@@ -60,6 +60,8 @@ data GrpcConfig =
     , retryNum :: !Int
     -- |Timeout of each RPC call (defaults to 5min if not given).
     , timeout :: !(Maybe Int)
+    -- |Whether to use TLS or not.
+    , useTls :: !Bool
     }
 
 data EnvData =
@@ -119,7 +121,7 @@ mkGrpcClient config mLogger =
         case target config of
           Just t  -> [auth, ("target", BS8.pack t)]
           Nothing -> [auth]
-      cfg = (grpcClientConfigSimple (host config) (port config) False)
+      cfg = (grpcClientConfigSimple (host config) (port config) (useTls config))
                  { _grpcClientConfigCompression = uncompressed
                  , _grpcClientConfigHeaders = header
                  , _grpcClientConfigTimeout = Timeout (fromMaybe 300 (timeout config))

--- a/src/Concordium/Client/Runner.hs
+++ b/src/Concordium/Client/Runner.hs
@@ -136,7 +136,7 @@ import Codec.CBOR.JSON
 -- they should be made in the context of the same 'withClient' so they reuse it.
 withClient :: Backend -> ClientMonad IO a -> IO a
 withClient bkend comp = do
-  let config = GrpcConfig (COM.grpcHost bkend) (COM.grpcPort bkend) (COM.grpcAuthenticationToken bkend) (COM.grpcTarget bkend) (COM.grpcRetryNum bkend) Nothing
+  let config = GrpcConfig (COM.grpcHost bkend) (COM.grpcPort bkend) (COM.grpcAuthenticationToken bkend) (COM.grpcTarget bkend) (COM.grpcRetryNum bkend) Nothing (COM.grpcUseTls bkend)
   runExceptT (mkGrpcClient config Nothing) >>= \case
       Left err -> logFatal ["Cannot establish connection to the node: " ++ show err]
       Right client -> do


### PR DESCRIPTION
## Purpose

Add support for connecting to the node using TLS.

It is used as

```
concordium-client --grpc-ip ... --secure raw GetConsensusInfo
```

Closes #176

## Changes

Add a `--secure` flag to the node connection configuration.

## Checklist

- [ ] My code follows the style of this project.
- [ ] The code compiles without warnings.
- [ ] I have performed a self-review of the changes.
- [ ] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [x] (If necessary) I have updated the CHANGELOG.