### PR TITLE
Support for deserialization of schemas in "module inspect" and "contract show".

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -5,6 +5,7 @@
 - Add support for protocol version 5.
 - Add a `--secure` flag to enable connecting to gRPC using TLS.
   All commands that query the node support this.
+- Add support of V3 schema contracts in `contract show` and `module inspect`.
 
 ## 4.2.0
 

--- a/concordium-client.cabal
+++ b/concordium-client.cabal
@@ -1,6 +1,6 @@
 cabal-version: 2.0
 
--- This file has been generated from package.yaml by hpack version 0.34.4.
+-- This file has been generated from package.yaml by hpack version 0.35.0.
 --
 -- see: https://github.com/sol/hpack
 
@@ -64,6 +64,7 @@ library
   other-modules:
       Paths_concordium_client
   autogen-modules:
+      Paths_concordium_client
       Proto.ConcordiumP2pRpc Proto.ConcordiumP2pRpc_Fields
   hs-source-dirs:
       src
@@ -125,6 +126,8 @@ executable concordium-client
   main-is: Main.hs
   other-modules:
       Paths_concordium_client
+  autogen-modules:
+      Paths_concordium_client
   hs-source-dirs:
       app
   default-extensions:
@@ -140,9 +143,9 @@ executable concordium-client
       base
     , concordium-client
     , optparse-applicative
+  default-language: Haskell2010
   if flag(static)
     ld-options: -static
-  default-language: Haskell2010
 
 executable middleware
   main-is: Main.hs
@@ -150,6 +153,8 @@ executable middleware
       Api
       Config
       Server
+      Paths_concordium_client
+  autogen-modules:
       Paths_concordium_client
   hs-source-dirs:
       middleware
@@ -191,15 +196,17 @@ executable middleware
     , wai-logger
     , wai-middleware-static
     , warp
+  default-language: Haskell2010
   if flag(middleware)
     buildable: True
   else
     buildable: False
-  default-language: Haskell2010
 
 executable tx-generator
   main-is: Main.hs
   other-modules:
+      Paths_concordium_client
+  autogen-modules:
       Paths_concordium_client
   hs-source-dirs:
       generator
@@ -222,11 +229,11 @@ executable tx-generator
     , mtl
     , optparse-applicative
     , time
+  default-language: Haskell2010
   if os(windows)
     ghc-options: -threaded
   if flag(static)
     ld-options: -static
-  default-language: Haskell2010
 
 test-suite concordium-client-test
   type: exitcode-stdio-1.0
@@ -245,6 +252,8 @@ test-suite concordium-client-test
       SimpleClientTests.QueryTransaction
       SimpleClientTests.SchemaParsingSpec
       SimpleClientTests.TransactionSpec
+      Paths_concordium_client
+  autogen-modules:
       Paths_concordium_client
   hs-source-dirs:
       test

--- a/src/Concordium/Client/Output.hs
+++ b/src/Concordium/Client/Output.hs
@@ -431,6 +431,7 @@ printModuleInspectInfo CI.ModuleInspectInfo{..} = do
       CI.ModuleInspectSigsV0{..} -> showContractSigsV0 mis0ContractSigs
       CI.ModuleInspectSigsV1{..} -> showContractSigsV1 mis1ContractSigs
       CI.ModuleInspectSigsV2{..} -> showContractSigsV2 mis2ContractSigs
+      CI.ModuleInspectSigsV3{..} -> showContractSigsV3 mis3ContractSigs
 
     showContractSigsV0 :: Map.Map Text CI.ContractSigsV0 -> [String]
     showContractSigsV0 = go . sortOn fst . Map.toList
@@ -465,6 +466,23 @@ printModuleInspectInfo CI.ModuleInspectInfo{..} = do
             showReceives [] = []
             showReceives ((fname, mSchema):remaining) = indentBy 4 (showContractFuncV2 fname mSchema) : showReceives remaining
 
+    showContractSigsV3 :: Map.Map Text CI.ContractSigsV3 -> [String]
+    showContractSigsV3 = go . sortOn fst . Map.toList
+      where go [] = []
+            go ((cname, CI.ContractSigsV3{..}):remaining) = [showContractFuncV2 cname csv3InitSig]
+                                                          ++ showReceives (sortOn fst . Map.toList $ csv3ReceiveSigs)
+                                                          ++ showEvents cs3EventSchemas
+                                                          ++ go remaining
+
+            showReceives :: [(Text, Maybe CS.FunctionSchemaV2)] -> [String]
+            showReceives [] = []
+            showReceives ((fname, mSchema):remaining) = indentBy 4 (showContractFuncV2 fname mSchema) : showReceives remaining
+
+            showEvents :: Maybe SchemaType -> [String]
+            showEvents es = case es of
+              Nothing -> []
+              Just _ -> [] -- VHTODO: Include JSON representation of event schema here.
+  
     showWarnings :: [FuncName] -> [String]
     showWarnings [] = []
     showWarnings xs =

--- a/src/Concordium/Client/Output.hs
+++ b/src/Concordium/Client/Output.hs
@@ -495,7 +495,7 @@ printModuleInspectInfo CI.ModuleInspectInfo{..} = do
             showEvents :: Maybe CS.SchemaType -> [String]
             showEvents stM = case stM of
               Nothing -> []
-              Just st -> [indentBy 4 $ "Events:", indentBy 8 $ showContractEventV3 $ Just st]
+              Just st -> [indentBy 4 "Events:", indentBy 8 $ showContractEventV3 $ Just st]
   
     showWarnings :: [FuncName] -> [String]
     showWarnings [] = []
@@ -712,7 +712,6 @@ showEvent verbose = \case
   Types.Resumed cAddr invokeSucceeded ->
     let invokeMsg :: Text = if invokeSucceeded then "succeeded" else "failed"
     in verboseOrNothing [i|resumed '#{cAddr}' after an interruption that #{invokeMsg}.|]
-  Types.Upgraded{..} -> verboseOrNothing $ printf "asd" -- VHTODO: Add this?
   where
     verboseOrNothing :: String -> Maybe String
     verboseOrNothing msg = if verbose then Just msg else Nothing

--- a/src/Concordium/Client/Output.hs
+++ b/src/Concordium/Client/Output.hs
@@ -341,8 +341,7 @@ printContractInfo ci namedOwner namedModRef =
            , [i|Balance:         #{showCcd ciAmount}|]]
       tell [ [i|Methods:|]]
       tellMethodsV1 ciMethods
-      tell [ [i|Events:|]]
-      tellEventsV1 ciMethods -- VHTODO: Make this look nice.
+      tellEventsV1 ciMethods
   where
     owner = showNamedAddress namedOwner
     showState = \case
@@ -365,7 +364,9 @@ printContractInfo ci namedOwner namedModRef =
       CI.NoSchemaV1{} -> return ()
       CI.WithSchemaV1{} -> return ()
       CI.WithSchemaV2{} -> return ()
-      CI.WithSchemaV3{..} -> tell [showContractEventV3 ws3Event] -- VHTODO: Make this look nice.
+      CI.WithSchemaV3{..} -> do
+        tell [ [i|Events:|]]
+        tell [indentBy 4 $ showContractEventV3 ws3Event]
 
 showContractFuncV0 :: Text -> Maybe CS.SchemaType -> String
 showContractFuncV0 funcName mParamSchema = case mParamSchema of
@@ -393,7 +394,7 @@ showContractFuncV2 funcName mFuncSchema = case mFuncSchema of
 showContractEventV3 :: Maybe SchemaType -> String
 showContractEventV3 stM = case stM of
   Nothing -> [i||]
-  Just st -> [i| #{indentBy 4 $ showPrettyJSON st}|] -- VHTODO: Make this look nice.
+  Just st -> [i| #{showPrettyJSON st}|]
 
 -- |Print module inspect info, i.e., the named moduleRef and its included contracts.
 -- If the init or receive signatures for a contract exist in the schema, they are also printed.
@@ -491,10 +492,10 @@ printModuleInspectInfo CI.ModuleInspectInfo{..} = do
             showReceives [] = []
             showReceives ((fname, mSchema):remaining) = indentBy 4 (showContractFuncV2 fname mSchema) : showReceives remaining
 
-            showEvents :: Maybe SchemaType -> [String]
-            showEvents es = case es of
+            showEvents :: Maybe CS.SchemaType -> [String]
+            showEvents stM = case stM of
               Nothing -> []
-              Just _ -> [] -- VHTODO: Include JSON representation of event schema here.
+              Just st -> [indentBy 4 $ "Events:", indentBy 8 $ showContractEventV3 $ Just st]
   
     showWarnings :: [FuncName] -> [String]
     showWarnings [] = []

--- a/src/Concordium/Client/Runner.hs
+++ b/src/Concordium/Client/Runner.hs
@@ -47,6 +47,7 @@ module Concordium.Client.Runner
 import           Concordium.Client.Utils
 import           Concordium.Client.Cli
 import           Concordium.Client.Config
+
 import           Concordium.Client.Commands          as COM
 import           Concordium.Client.Export
 import           Concordium.Client.GRPC

--- a/src/Concordium/Client/Types/Contract/Info.hs
+++ b/src/Concordium/Client/Types/Contract/Info.hs
@@ -473,14 +473,14 @@ constructModuleInspectInfo namedModRef wasmVersion moduleSchema exportedFuncName
               where
                     go :: Map.Map Text ContractSigsV3 -> [CS.FuncName] -> [(Text, CS.ContractSchemaV3)] -> (Map.Map Text ContractSigsV3, [CS.FuncName])
                     go sigMap errors [] = (sigMap, errors)
-                    go sigMap errors ((cname, CS.ContractSchemaV3{..}):remaining) =
+                    go sigMap errors ((cname, cs@CS.ContractSchemaV3{..}):remaining) =
                       case Map.lookup cname sigMap of
                         Nothing -> let receiveErrors = map (CS.ReceiveFuncName cname) . Map.keys $ cs3ReceiveSigs
                                        errors' = CS.InitFuncName cname : receiveErrors ++ errors
                                    in go sigMap errors' remaining -- Schema has init signature for a contract not in the module.
                         Just ContractSigsV3{..} ->
                           let (updatedCsReceiveSigs, receiveErrors) = updateReceiveSigs cname csv3ReceiveSigs [] (Map.toList cs3ReceiveSigs)
-                              sigMap' = Map.insert cname (ContractSigsV3 {csv3InitSig = cs3InitSig, csv3ReceiveSigs = updatedCsReceiveSigs, cs3EventSchema = cs3EventSchema}) sigMap
+                              sigMap' = Map.insert cname (ContractSigsV3 {csv3InitSig = cs3InitSig, csv3ReceiveSigs = updatedCsReceiveSigs, cs3EventSchema = CS.cs3EventSchema cs}) sigMap
                           in go sigMap' (receiveErrors ++ errors) remaining
 
                     updateReceiveSigs :: Text -> Map.Map Text (Maybe CS.FunctionSchemaV2) -> [CS.FuncName]

--- a/src/Concordium/Client/Types/Contract/Parameter.hs
+++ b/src/Concordium/Client/Types/Contract/Parameter.hs
@@ -86,9 +86,7 @@ getJSONUsingSchema typ = case typ of
     fields' <- getFieldsAsJSON fields
     return $ AE.object [AE.fromText name .= fields']
   TaggedEnum variants -> do
-    idx <- if length variants <= 255
-           then fromIntegral <$> S.getWord8
-           else fromIntegral <$> S.getWord32le -- VHTODO: Check how indices are serialized.
+    idx <- fromIntegral <$> S.getWord8
     (name, fields) <- case variants Map.!? idx of
                       Just v -> return v
                       Nothing -> fail [i|Variant with index #{idx} does not exist for TaggedEnum.|]
@@ -257,7 +255,7 @@ putJSONUsingSchema typ json = case (typ, json) of
   (tEnum@(TaggedEnum variants), AE.Object obj) -> case KM.toList obj of
     [] -> Left [i|The object provided was empty, but it should have contained a variant of the following tagged enum:\n#{showPrettyJSON tEnum}.|]
     [(tag, val@(AE.Array vec))] -> case AE.toString tag of
-      [c] -> let idx = ((fromIntegral . ord) c :: Word8) in case V.toList vec of -- VHTODO: Is this sort of conversion OK? Would be nice if we could simply convert Key to Word8 somehow, or have Map Word8 Value...
+      [c] -> let idx = ((fromIntegral . ord) c :: Word8) in case V.toList vec of -- TODO: Is this sort of conversion OK?
         [nameVal, fieldsVal] -> case nameVal of 
           AE.String name -> case variants Map.!? idx of
             Nothing -> Left [i|No enum variant corresponds to tag '#{tag}' in:\n#{showPrettyJSON tEnum}|]

--- a/src/Concordium/Client/Types/Contract/Schema.hs
+++ b/src/Concordium/Client/Types/Contract/Schema.hs
@@ -189,6 +189,7 @@ getVersionedModuleSchema = S.label "ModuleSchema" $ do
       0 -> ModuleSchemaV0 <$> getMapOfWithSizeLen Four getText S.get
       1 -> ModuleSchemaV1 <$> getMapOfWithSizeLen Four getText S.get
       2 -> ModuleSchemaV2 <$> getMapOfWithSizeLen Four getText S.get
+      3 -> ModuleSchemaV3 <$> getMapOfWithSizeLen Four getText S.get
       v -> fail $ "Unsupported schema version: " ++ show v
 
 -- |Create a getter based on the wasm version.

--- a/src/Concordium/Client/Types/Contract/Schema.hs
+++ b/src/Concordium/Client/Types/Contract/Schema.hs
@@ -20,6 +20,7 @@ module Concordium.Client.Types.Contract.Schema(
   getListOfWithSizeLen,
   lookupFunctionSchemaV1,
   lookupFunctionSchemaV2,
+  lookupFunctionSchemaV3,
   lookupParameterSchema,
   lookupReturnValueSchema,
   lookupErrorSchema,

--- a/src/Concordium/Client/Types/Contract/Schema.hs
+++ b/src/Concordium/Client/Types/Contract/Schema.hs
@@ -463,7 +463,7 @@ data SchemaType =
   | ILeb128 Word32
   | ByteList SizeLength
   | ByteArray Word32
-  | EnumTag (Map Word8 (Text, Fields))
+  | TaggedEnum (Map Word8 (Text, Fields))
   deriving (Eq, Generic, Show)
 
 instance Hashable SchemaType
@@ -509,7 +509,7 @@ instance AE.ToJSON SchemaType where
     ILeb128 _ -> AE.String "<String with signed integer>"
     ByteList _ -> AE.String "<String with lowercase hex>"
     ByteArray _ -> AE.String "<String with lowercase hex>"
-    EnumTag variants -> AE.object ["EnumTag" .= (toJsonArray . map (\(k, v) -> AE.object [AE.fromText k .= v]) $ (\(k,v) -> (pack $ show k, v)) <$> Map.toList variants)]
+    TaggedEnum variants -> AE.object ["TaggedEnum" .= (toJsonArray . map (\(k, v) -> AE.object [AE.fromText k .= v]) $ (\(k,v) -> (pack $ show k, v)) <$> Map.toList variants)]
     where toJsonArray = AE.Array . V.fromList
 
 instance S.Serialize SchemaType where
@@ -547,7 +547,7 @@ instance S.Serialize SchemaType where
       28 -> S.label "ILeb128"  $ ILeb128 <$> S.getWord32le
       29 -> S.label "ByteList" $ ByteList <$> S.get
       30 -> S.label "ByteArray"  $ ByteArray <$> S.getWord32le
-      31 -> S.label "EnumTag" $ EnumTag <$> getMapOfWithSizeLen Four S.getWord8 (S.getTwoOf getText S.get)
+      31 -> S.label "TaggedEnum" $ TaggedEnum <$> getMapOfWithSizeLen Four S.getWord8 (S.getTwoOf getText S.get)
       x  -> fail [i|Invalid SchemaType tag: #{x}|]
 
 
@@ -584,7 +584,7 @@ instance S.Serialize SchemaType where
     ILeb128 sl          -> S.putWord8 28 <> S.putWord32le sl
     ByteList sl         -> S.putWord8 29 <> S.put sl
     ByteArray sl        -> S.putWord8 30 <> S.putWord32le sl
-    EnumTag m           -> S.putWord8 31 <> putMapOfWithSizeLen Four S.putWord8 (S.putTwoOf putText S.put) m
+    TaggedEnum m           -> S.putWord8 31 <> putMapOfWithSizeLen Four S.putWord8 (S.putTwoOf putText S.put) m
 
 -- |Parallel to SizeLength defined in contracts-common (Rust).
 -- Must stay in sync.

--- a/src/Concordium/Client/Types/Contract/Schema.hs
+++ b/src/Concordium/Client/Types/Contract/Schema.hs
@@ -12,6 +12,7 @@ module Concordium.Client.Types.Contract.Schema(
   SizeLength(..),
   FunctionSchemaV1(..),
   FunctionSchemaV2(..),
+  EventSchemaV3,
   decodeEmbeddedSchema,
   decodeEmbeddedSchemaAndExports,
   decodeModuleSchema,
@@ -21,6 +22,7 @@ module Concordium.Client.Types.Contract.Schema(
   lookupFunctionSchemaV1,
   lookupFunctionSchemaV2,
   lookupFunctionSchemaV3,
+  lookupEventSchema,
   lookupParameterSchema,
   lookupReturnValueSchema,
   lookupErrorSchema,
@@ -136,7 +138,7 @@ lookupEventSchema moduleSchema contrName =
     ModuleSchemaV0 {} -> Nothing
     ModuleSchemaV1 {} -> Nothing
     ModuleSchemaV2 {} -> Nothing
-    ModuleSchemaV3 {..} -> Map.lookup contrName ms3ContractSchemas >>= cs3EventSchemas
+    ModuleSchemaV3 {..} -> Map.lookup contrName ms3ContractSchemas >>= cs3EventSchema
 
 -- |Lookup the 'FunctionSchemaV1' of a 'ContractSchemaV1'.
 lookupFunctionSchemaV1 :: ContractSchemaV1 -> FuncName -> Maybe FunctionSchemaV1
@@ -235,7 +237,7 @@ data ContractSchemaV3
   = ContractSchemaV3 -- ^ Describes the schemas of a V1 smart contract.
   { cs3InitSig :: Maybe FunctionSchemaV2 -- ^ Schema for the init function.
   , cs3ReceiveSigs :: Map Text FunctionSchemaV2 -- ^ Schemas for the receive functions.
-  , cs3EventSchemas :: Maybe SchemaType -- ^ Schemas for the events
+  , cs3EventSchema :: Maybe SchemaType -- ^ Schemas for the events
   }
   deriving (Eq, Show, Generic)
 
@@ -267,7 +269,7 @@ instance S.Serialize ContractSchemaV3 where
   get = S.label "ContractSchemaV3" $ do
     cs3InitSig <- S.label "cs3InitSig" S.get
     cs3ReceiveSigs <- S.label "cs3ReceiveSigs" $ getMapOfWithSizeLen Four getText S.get
-    cs3EventSchemas <- S.label "cs3EventSigs" S.get -- TODO: Add the event schema serialization here
+    cs3EventSchema <- S.label "cs3EventSigs" S.get -- TODO: Add the event schema serialization here
     pure ContractSchemaV3{..}
   put ContractSchemaV3 {..} = S.put cs3InitSig <> putMapOfWithSizeLen Four putText S.put cs3ReceiveSigs
 
@@ -335,6 +337,9 @@ data FunctionSchemaV2
                  , fs2Error :: SchemaType
                  }
   deriving (Eq, Show, Generic)
+
+-- |V3 Schema for events in a V1 smart contract
+type EventSchemaV3 = SchemaType
 
 instance AE.ToJSON FunctionSchemaV2
 


### PR DESCRIPTION
## Purpose

Add support for printing V3 schemas in "module inspect" and "contract show". 

## Changes

- Add tagged enum type to SchemaType and implement (de)serializing.
- Add support for (de)serializing bytestrings using tagged enums (to be used for deserializing contract events in transaction outcomes).
- Add contract/module V3 schema datatypes.
- Extend `contract show` and `module inspect`to print event schema information for schema V3 contracts.

What was not tested:
- Serializing enum tags from user-provided files, but this should come OOTB with extended SchemaType?

## Checklist

- [X] My code follows the style of this project.
- [X] The code compiles without warnings.
- [X] I have performed a self-review of the changes.
- [X] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [X] (If necessary) I have updated the CHANGELOG.