### PR TITLE
Improve disconnect detection and GOAWAY handling.

### DIFF
--- a/concordium-client.cabal
+++ b/concordium-client.cabal
@@ -91,7 +91,6 @@ library
     , cborg-json
     , cereal
     , concordium-base
-    , concurrent-extra >=0.7
     , containers
     , cookie
     , cryptonite

--- a/middleware/Server.hs
+++ b/middleware/Server.hs
@@ -6,6 +6,7 @@ import           Data.Function ((&))
 import           Data.List.Split
 import           Data.Maybe
 import qualified Data.Text as T
+import qualified Data.Text.IO as T
 import           Network.Wai (Application, Middleware)
 import qualified Network.Wai.Handler.Warp as W
 import           Network.Wai.Middleware.AddHeaders (addHeaders)
@@ -41,9 +42,9 @@ runHttp middlewares = do
         _ ->
           error $ "Could not parse host:port for given NODE_URL: " ++ T.unpack nodeUrl
 
-    grpcConfig = GrpcConfig { host = nodeHost, port = nodePort, grpcAuthenticationToken = (T.unpack grpcAdminToken), target = Nothing, retryNum = 5, timeout = Just to, useTls = isJust secure }
+    grpcConfig = GrpcConfig { host = nodeHost, port = nodePort, grpcAuthenticationToken = T.unpack grpcAdminToken, target = Nothing, retryNum = 5, timeout = Just to, useTls = isJust secure }
 
-  runExceptT (mkGrpcClient grpcConfig Nothing) >>= \case
+  runExceptT (mkGrpcClient grpcConfig (Just T.putStrLn)) >>= \case
     Left err -> fail (show err) -- cannot connect to grpc server
     Right nodeBackend -> do
       let

--- a/package.yaml
+++ b/package.yaml
@@ -95,7 +95,6 @@ library:
     - microlens-platform
     - transformers
     - uri-encode >= 1.5
-    - concurrent-extra >= 0.7
     - async >= 2.2
     - vector >= 0.12
     - string-interpolate

--- a/src/Concordium/Client/GRPC.hs
+++ b/src/Concordium/Client/GRPC.hs
@@ -484,7 +484,7 @@ acquireRead RWLock{..} = mask_ go
         go
 
 -- |Acquire a write lock. This will block when there are active readers or
--- writers. When this is operation is blocked it also blocks new readers from
+-- writers. When this operation is blocked it also blocks new readers from
 -- acquiring the lock.
 acquireWrite :: RWLock -> IO ()
 acquireWrite RWLock{..} = mask_ $ go False

--- a/src/Concordium/Client/Runner.hs
+++ b/src/Concordium/Client/Runner.hs
@@ -150,7 +150,7 @@ withClient bkend comp = do
               runExceptT (close ref) >>= \case
                 Left err -> logFatal ["Error closing connection: " ++ show err]
                 Right () -> return ()
-        let closeConnection = closeOrFail =<< (readIORef $ grpc client)
+        let closeConnection = closeOrFail =<< (fmap (fmap snd) . readIORef $ grpc client)
         finally body closeConnection
 
 withClientJson :: (FromJSON a) => Backend -> ClientMonad IO (Either String Value) -> IO a


### PR DESCRIPTION
There are two main changes
- use an RWLock that prefers writers, so that new queries do not prevent a reconnect
- Detect GOAWAY frames more directly instead of waiting for timeout.

## Purpose

Fixes #188 

## Changes

- Use the RWLock we use in the node, which strongly prefers writers.
- Add custom handling of GoAway frames and reconnect immediately.

## Checklist

- [ ] My code follows the style of this project.
- [ ] The code compiles without warnings.
- [ ] I have performed a self-review of the changes.
- [ ] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [ ] (If necessary) I have updated the CHANGELOG.
