### PR TITLE
Improve printing of parameters and events in transaction outcomes in printTransactionStatus.

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+
+## 5.0.1
+
 - Add support for protocol version 5.
 - Add a `--secure` flag to enable connecting to gRPC using TLS.
   All commands that query the node support this.

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -2,12 +2,8 @@
 
 ## Unreleased
 
-
 ## 5.0.1
 
-- Add support for protocol version 5.
-- Add a `--secure` flag to enable connecting to gRPC using TLS.
-  All commands that query the node support this.
 - Add support of contract schema V3.
 	  - V3 schemas offer the same options as V2, but also optionally includes a schema for contract events.
 	  - `transaction status` now displays contract events, and a schema can be provided with `--schema`, which 
@@ -15,8 +11,15 @@
       contract, if present.
 	  - This enables concordium-client to interact with contracts and schemas 
 	    using `concordium-std` version 5.
-- Improved formatting of `transaction status` output.
+- Improved formatting of `transaction status` output using contract schemas if
+  they are available for displaying contract events.
 - Output function parameters as hex strings in `transaction status`.
+
+## 5.0.0
+
+- Add support for protocol version 5.
+- Add a `--secure` flag to enable connecting to gRPC using TLS.
+  All commands that query the node support this.
 
 ## 4.2.0
 

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -15,7 +15,8 @@
       contract, if present.
 	  - This enables concordium-client to interact with contracts and schemas 
 	    using `concordium-std` version 5.
-- Printing of parameters as raw, hexadecimal output.
+- Improved formatting of `transaction status` output.
+- Output function parameters as hex strings in `transaction status`.
 
 ## 4.2.0
 

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -12,6 +12,7 @@
       contract, if present.
 	  - This enables concordium-client to interact with contracts and schemas 
 	    using `concordium-std` version 5.
+- Printing of parameters as raw, hexadecimal output.
 
 ## 4.2.0
 

--- a/concordium-client.cabal
+++ b/concordium-client.cabal
@@ -1,6 +1,6 @@
 cabal-version: 2.0
 
--- This file has been generated from package.yaml by hpack version 0.35.0.
+-- This file has been generated from package.yaml by hpack version 0.34.4.
 --
 -- see: https://github.com/sol/hpack
 
@@ -64,7 +64,6 @@ library
   other-modules:
       Paths_concordium_client
   autogen-modules:
-      Paths_concordium_client
       Proto.ConcordiumP2pRpc Proto.ConcordiumP2pRpc_Fields
   hs-source-dirs:
       src
@@ -125,8 +124,6 @@ executable concordium-client
   main-is: Main.hs
   other-modules:
       Paths_concordium_client
-  autogen-modules:
-      Paths_concordium_client
   hs-source-dirs:
       app
   default-extensions:
@@ -142,9 +139,9 @@ executable concordium-client
       base
     , concordium-client
     , optparse-applicative
-  default-language: Haskell2010
   if flag(static)
     ld-options: -static
+  default-language: Haskell2010
 
 executable middleware
   main-is: Main.hs
@@ -152,8 +149,6 @@ executable middleware
       Api
       Config
       Server
-      Paths_concordium_client
-  autogen-modules:
       Paths_concordium_client
   hs-source-dirs:
       middleware
@@ -195,17 +190,15 @@ executable middleware
     , wai-logger
     , wai-middleware-static
     , warp
-  default-language: Haskell2010
   if flag(middleware)
     buildable: True
   else
     buildable: False
+  default-language: Haskell2010
 
 executable tx-generator
   main-is: Main.hs
   other-modules:
-      Paths_concordium_client
-  autogen-modules:
       Paths_concordium_client
   hs-source-dirs:
       generator
@@ -228,11 +221,11 @@ executable tx-generator
     , mtl
     , optparse-applicative
     , time
-  default-language: Haskell2010
   if os(windows)
     ghc-options: -threaded
   if flag(static)
     ld-options: -static
+  default-language: Haskell2010
 
 test-suite concordium-client-test
   type: exitcode-stdio-1.0
@@ -251,8 +244,6 @@ test-suite concordium-client-test
       SimpleClientTests.QueryTransaction
       SimpleClientTests.SchemaParsingSpec
       SimpleClientTests.TransactionSpec
-      Paths_concordium_client
-  autogen-modules:
       Paths_concordium_client
   hs-source-dirs:
       test

--- a/concordium-client.cabal
+++ b/concordium-client.cabal
@@ -1,6 +1,6 @@
 cabal-version: 2.0
 
--- This file has been generated from package.yaml by hpack version 0.34.4.
+-- This file has been generated from package.yaml by hpack version 0.35.0.
 --
 -- see: https://github.com/sol/hpack
 
@@ -64,6 +64,7 @@ library
   other-modules:
       Paths_concordium_client
   autogen-modules:
+      Paths_concordium_client
       Proto.ConcordiumP2pRpc Proto.ConcordiumP2pRpc_Fields
   hs-source-dirs:
       src
@@ -124,6 +125,8 @@ executable concordium-client
   main-is: Main.hs
   other-modules:
       Paths_concordium_client
+  autogen-modules:
+      Paths_concordium_client
   hs-source-dirs:
       app
   default-extensions:
@@ -139,9 +142,9 @@ executable concordium-client
       base
     , concordium-client
     , optparse-applicative
+  default-language: Haskell2010
   if flag(static)
     ld-options: -static
-  default-language: Haskell2010
 
 executable middleware
   main-is: Main.hs
@@ -149,6 +152,8 @@ executable middleware
       Api
       Config
       Server
+      Paths_concordium_client
+  autogen-modules:
       Paths_concordium_client
   hs-source-dirs:
       middleware
@@ -190,15 +195,17 @@ executable middleware
     , wai-logger
     , wai-middleware-static
     , warp
+  default-language: Haskell2010
   if flag(middleware)
     buildable: True
   else
     buildable: False
-  default-language: Haskell2010
 
 executable tx-generator
   main-is: Main.hs
   other-modules:
+      Paths_concordium_client
+  autogen-modules:
       Paths_concordium_client
   hs-source-dirs:
       generator
@@ -221,11 +228,11 @@ executable tx-generator
     , mtl
     , optparse-applicative
     , time
+  default-language: Haskell2010
   if os(windows)
     ghc-options: -threaded
   if flag(static)
     ld-options: -static
-  default-language: Haskell2010
 
 test-suite concordium-client-test
   type: exitcode-stdio-1.0
@@ -244,6 +251,8 @@ test-suite concordium-client-test
       SimpleClientTests.QueryTransaction
       SimpleClientTests.SchemaParsingSpec
       SimpleClientTests.TransactionSpec
+      Paths_concordium_client
+  autogen-modules:
       Paths_concordium_client
   hs-source-dirs:
       test

--- a/concordium-client.cabal
+++ b/concordium-client.cabal
@@ -5,7 +5,7 @@ cabal-version: 2.0
 -- see: https://github.com/sol/hpack
 
 name:           concordium-client
-version:        5.0.0
+version:        5.0.1
 description:    Please see the README on GitHub at <https://github.com/Concordium/concordium-client#readme>
 homepage:       https://github.com/Concordium/concordium-client#readme
 bug-reports:    https://github.com/Concordium/concordium-client/issues

--- a/package.yaml
+++ b/package.yaml
@@ -1,5 +1,5 @@
 name:                concordium-client
-version:             5.0.0
+version:             5.0.1
 github:              "Concordium/concordium-client"
 author:              "Concordium"
 maintainer:          "developers@concordium.com"

--- a/src/Concordium/Client/Output.hs
+++ b/src/Concordium/Client/Output.hs
@@ -42,7 +42,6 @@ import Data.List (foldl', intercalate, nub, sortOn, partition)
 import Data.Maybe
 import Data.Word (Word64)
 import Data.Ratio
-import qualified Data.Serialize as SE
 import Data.String.Interpolate (i)
 import Data.Text (Text)
 import qualified Data.Text as Text

--- a/src/Concordium/Client/Output.hs
+++ b/src/Concordium/Client/Output.hs
@@ -34,7 +34,6 @@ import qualified Data.Aeson as AE
 import qualified Data.Aeson.Types as AE
 import Data.Bool
 import qualified Data.ByteString as BS
-import qualified Data.ByteString.Builder as BSB
 import qualified Data.ByteString.Short as BSS
 import qualified Data.ByteString.Lazy as BSL
 import Data.Functor
@@ -770,9 +769,6 @@ showEvent verbose stM = \case
             else [i|, of which #{length $ filter isJust $ map toJSON' evs} were succesfully parsed. |])
         <> [i|Got:\n|] <> intercalate "\n" (map eventToString evs)
       where
-        -- Show a hexadecimal string representation of contract event data.
-        toHex :: Wasm.ContractEvent -> String
-        toHex (Wasm.ContractEvent bs) = show . BSB.toLazyByteString . BSB.byteStringHex $ SE.runPut $ SE.putShortByteString bs
         -- Attempt to decode the contract event if the schema is provided.
         -- If there is no schema, or decoding fails @Nothing@ is returned.
         toJSON' :: Wasm.ContractEvent -> Maybe String
@@ -784,7 +780,7 @@ showEvent verbose stM = \case
         -- Show a string representation of the contract event.
         eventToString :: Wasm.ContractEvent -> String
         eventToString e = case toJSON' e of
-          Nothing -> [i|Event(raw): #{toHex e}|]
+          Nothing -> [i|Event(raw): #{show e}|]
           Just json -> [i|Event(parsed):\n#{indentBy 4 json}|] 
 
 -- |Return string representation of reject reason.


### PR DESCRIPTION
## Purpose

Currently the standard `deriving Show` is used for Parameters and ContractEvent. Furthermore logging of transaction events is an eyesore and could benefit from indentation.

## Changes

- Change dependencies on `concordium-base` to latest version, s.t. `show` applied to `Parameter` and `ContractEvent` now prints raw data in the form of a hexadecimal string.
- Indent and unindent transaction outcomes on `Interrupted` and `Resumed` when printing transaction status.

## Checklist

- [X] My code follows the style of this project.
- [X] The code compiles without warnings.
- [X] I have performed a self-review of the changes.
- [X] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [X] (If necessary) I have updated the CHANGELOG.