### PR TITLE
Use stack 2.9.1.

### DIFF
--- a/concordium-client.cabal
+++ b/concordium-client.cabal
@@ -1,6 +1,6 @@
 cabal-version: 2.0
 
--- This file has been generated from package.yaml by hpack version 0.34.4.
+-- This file has been generated from package.yaml by hpack version 0.35.0.
 --
 -- see: https://github.com/sol/hpack
 
@@ -64,6 +64,7 @@ library
   other-modules:
       Paths_concordium_client
   autogen-modules:
+      Paths_concordium_client
       Proto.ConcordiumP2pRpc Proto.ConcordiumP2pRpc_Fields
   hs-source-dirs:
       src
@@ -124,6 +125,8 @@ executable concordium-client
   main-is: Main.hs
   other-modules:
       Paths_concordium_client
+  autogen-modules:
+      Paths_concordium_client
   hs-source-dirs:
       app
   default-extensions:
@@ -139,9 +142,9 @@ executable concordium-client
       base
     , concordium-client
     , optparse-applicative
+  default-language: Haskell2010
   if flag(static)
     ld-options: -static
-  default-language: Haskell2010
 
 executable middleware
   main-is: Main.hs
@@ -149,6 +152,8 @@ executable middleware
       Api
       Config
       Server
+      Paths_concordium_client
+  autogen-modules:
       Paths_concordium_client
   hs-source-dirs:
       middleware
@@ -190,15 +195,17 @@ executable middleware
     , wai-logger
     , wai-middleware-static
     , warp
+  default-language: Haskell2010
   if flag(middleware)
     buildable: True
   else
     buildable: False
-  default-language: Haskell2010
 
 executable tx-generator
   main-is: Main.hs
   other-modules:
+      Paths_concordium_client
+  autogen-modules:
       Paths_concordium_client
   hs-source-dirs:
       generator
@@ -221,11 +228,11 @@ executable tx-generator
     , mtl
     , optparse-applicative
     , time
+  default-language: Haskell2010
   if os(windows)
     ghc-options: -threaded
   if flag(static)
     ld-options: -static
-  default-language: Haskell2010
 
 test-suite concordium-client-test
   type: exitcode-stdio-1.0
@@ -244,6 +251,8 @@ test-suite concordium-client-test
       SimpleClientTests.QueryTransaction
       SimpleClientTests.SchemaParsingSpec
       SimpleClientTests.TransactionSpec
+      Paths_concordium_client
+  autogen-modules:
       Paths_concordium_client
   hs-source-dirs:
       test
@@ -278,4 +287,3 @@ test-suite concordium-client-test
     , unordered-containers
     , vector
   default-language: Haskell2010
-

--- a/scripts/distributables/linux-distributable-concordium-client.Dockerfile
+++ b/scripts/distributables/linux-distributable-concordium-client.Dockerfile
@@ -19,7 +19,7 @@ RUN wget -q https://s3-eu-west-1.amazonaws.com/static-libraries.concordium.com/g
         cd .. && \
         rm -rf ghc-${GHC_VERSION}-x86_64-unknown-linux-integer-gmp.tar.xz ghc-${GHC_VERSION}-x86_64-unknown-linux
 
-ARG STACK_VERSION=2.7.5
+ARG STACK_VERSION=2.9.1
 RUN wget -q https://github.com/commercialhaskell/stack/releases/download/v${STACK_VERSION}/stack-${STACK_VERSION}-linux-x86_64.tar.gz && \
         tar -xf stack-${STACK_VERSION}-linux-x86_64.tar.gz && \
         mkdir -p $HOME/.stack/bin && \


### PR DESCRIPTION
## Purpose

Use stack 2.9.1 for building the project. Stack 2.7.5 produces warnings when building with ghc 9.2.5. 
Stack 2.9.1 comes with a new hpack version which in turn will modify cabal file.

## Changes

Build the project with stack 2.9.1 and update the cabal file for the project.

- [x] Update base ptr when the associated PR for base has been merged. https://github.com/Concordium/concordium-base/pull/294

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [x] (If necessary) I have updated the CHANGELOG.

