### PR TITLE
Migrate family of `raw` client commands to GRPC V2.

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -2,6 +2,24 @@
 
 ## Unreleased
 
+- `raw` commands now use the V2 GRPC API exposed by the node. This introduces
+  some potentially breaking changes:
+    - Commands `raw GetTransactionStatusInBlock`, `raw StartBaker`, `raw StopBaker`,
+      `raw JoinNetwork` and ` raw LeaveNetwork` have been removed.
+    - Command `raw GetBlockSummary` has been removed, and replaced by the commands
+      `raw GetBlockPendingUpdates`, `raw GetBlockSpecialEvents`,
+      `raw GetBlockChainParameters` `raw GetBlockFinalizationSummary`. These provide
+      more granular way to access to the same data.
+    - `raw BanNode` and `raw BanNode` no longer support node IDs, but now rather an
+      take an IP address.
+    - `raw DumpStart` takes a parameter specifying the path of the file to write
+      dumped packets to, and furthermore supports a flag to specify whether raw
+      packets should be written to the file.
+    - Output of `raw GetBannedPeers` prints a JSON file containing a list of
+      strings each corresponding to a banned IP.
+    - Output of `raw GetPeerUptime` now prints an integer representing the uptime
+      of the node.
+
 ## 5.0.2
 
 - Receive function parameters are now displayed as JSON in `transaction status`

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -10,7 +10,7 @@
       `raw GetBlockPendingUpdates`, `raw GetBlockSpecialEvents`,
       `raw GetBlockChainParameters` `raw GetBlockFinalizationSummary`. These provide
       a more granular way of accessing to the same data.
-    - `raw BanNode` and `raw BanNode` no longer support node IDs, but now rather an
+    - `raw BanNode` and `raw UnbanNode` no longer support node IDs, but now rather an
       take just an IP address.
     - `raw DumpStart` takes a parameter specifying the path of the file to write
       dumped packets to, and furthermore supports a flag to specify whether raw

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -10,16 +10,20 @@
       `raw GetBlockPendingUpdates`, `raw GetBlockSpecialEvents`,
       `raw GetBlockChainParameters` `raw GetBlockFinalizationSummary`. These provide
       a more granular way of accessing to the same data.
-    - `raw BanNode` and `raw UnbanNode` no longer support node IDs, but now rather an
+    - `raw BanNode` and `raw UnbanNode` no longer support node IDs, but now rather
       take just an IP address.
     - `raw DumpStart` takes a parameter specifying the path of the file to write
       dumped packets to, and furthermore supports a flag to specify whether raw
       packets should be written to the file.
-    - Output of `raw GetBannedPeers` prints a JSON file containing a list of
-      strings each corresponding to a banned IP.
+    - Output of `raw GetBannedPeers` prints a JSON list of banned IP addresses,
+      represented as strings.
     - Output of `raw GetPeerUptime` now prints an integer representing the uptime
-      of the node.
-    - Slight changes to `raw GetNodeInfo` and `raw GetPeerData` output.
+      of the node in milliseconds.
+    - Slight changes to `raw GetNodeInfo`. Notably the baker ID is now included in
+      the output when the node is in the baker or finalization committee. Various
+      consensus-related details about the node is also elaborated upon.
+    - Slight changes to `raw GetPeerData` output. Notably the catch-up status and
+      consensus-related details about the peer is elaborated upon.
 
 ## 5.0.2
 

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -19,6 +19,7 @@
       strings each corresponding to a banned IP.
     - Output of `raw GetPeerUptime` now prints an integer representing the uptime
       of the node.
+    - Slight changes to `raw GetNodeInfo` and `raw GetPeerData` output.
 
 ## 5.0.2
 

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -9,9 +9,9 @@
     - Command `raw GetBlockSummary` has been removed, and replaced by the commands
       `raw GetBlockPendingUpdates`, `raw GetBlockSpecialEvents`,
       `raw GetBlockChainParameters` `raw GetBlockFinalizationSummary`. These provide
-      more granular way to access to the same data.
+      a more granular way of accessing to the same data.
     - `raw BanNode` and `raw BanNode` no longer support node IDs, but now rather an
-      take an IP address.
+      take just an IP address.
     - `raw DumpStart` takes a parameter specifying the path of the file to write
       dumped packets to, and furthermore supports a flag to specify whether raw
       packets should be written to the file.

--- a/src/Concordium/Client/GRPC2.hs
+++ b/src/Concordium/Client/GRPC2.hs
@@ -74,12 +74,6 @@ import qualified Proto.V2.Concordium.Types as Proto
 import qualified Proto.V2.Concordium.Types as ProtoFields
 import qualified Proto.V2.Concordium.Types_Fields as Proto
 import qualified Proto.V2.Concordium.Types_Fields as ProtoFields
-import Data.Aeson
-import Data.Aeson.TH
-import Data.Aeson.Types (Parser)
-import Concordium.Utils
-import Data.Char
-import Concordium.Types.Queries (EChainParametersAndKeys)
 
 -- |A helper function that serves as an inverse to `mkSerialize`,
 --

--- a/src/Concordium/Client/GRPC2.hs
+++ b/src/Concordium/Client/GRPC2.hs
@@ -1727,7 +1727,7 @@ instance FromProto Proto.Sha256Hash where
     fromProto h =
         case deMkSerialize h of
             Left err -> fromProtoFail $
-                "Unable to convert 'LeadershipElectionNonce': " <> err
+                "Unable to convert 'Sha256Hash': " <> err
             Right hash -> return hash
 
 instance FromProto Proto.ProtocolUpdate where

--- a/src/Concordium/Client/GRPC2.hs
+++ b/src/Concordium/Client/GRPC2.hs
@@ -18,7 +18,6 @@ import Control.Monad.State.Strict
 import Data.ByteString (ByteString)
 import Data.Coerce
 import Data.IORef (readIORef, atomicWriteIORef)
-import Data.Maybe (maybeToList)
 import Data.ProtoLens (defMessage)
 import Data.ProtoLens.Service.Types
 import Data.String (fromString)
@@ -230,9 +229,9 @@ decodeAndConsume bs = do
             then return v
             else fail "Did not consume the input."
 
--- |Type alias for the output type of fromProto.
--- Is @Left@ wrapping an error string if the conversion failed
--- and @Right@ wrapping the converted value otherwise.
+-- |The result of converting a protocol buffer message with `fromProto`.
+-- A @Left@ wrapping an error string indicates that the conversion failed
+-- and a @Right@ wrapping the converted value indicates that it succeeded.
 type FromProtoResult a = Either String a
 
 -- |A helper class analogous to something like Aeson's FromJSON.

--- a/src/Concordium/Client/LegacyCommands.hs
+++ b/src/Concordium/Client/LegacyCommands.hs
@@ -250,7 +250,7 @@ getBlockChainParametersCommand =
        (GetBlockChainParameters <$>
         optional (strArgument (metavar "BLOCK-HASH" <> help "Hash of the block to query"))
        )
-       (progDesc "Query the gRPC server for the special events in a specific block."))
+       (progDesc "Query the gRPC server for the chain parameters at a specific block."))
 
 getBlockFinalizationSummaryCommand :: Mod CommandFields LegacyCmd
 getBlockFinalizationSummaryCommand =
@@ -427,7 +427,7 @@ getPeerUptimeCommand =
      "GetPeerUptime"
     (info
        (pure GetPeerUptime)
-       (progDesc "Get the node uptime."))
+       (progDesc "Get the node uptime in milliseconds."))
 
 
 banNodeCommand :: Mod CommandFields LegacyCmd

--- a/src/Concordium/Client/LegacyCommands.hs
+++ b/src/Concordium/Client/LegacyCommands.hs
@@ -32,9 +32,18 @@ data LegacyCmd
       { legacyEvery     :: !Bool,
         legacyBlockHash :: !(Maybe Text)
       } -- ^ Queries the gRPC server for the information of a specific block
-  | GetBlockSummary
+  | GetBlockPendingUpdates
       { legacyBlockHash :: !(Maybe Text)
-      } -- ^ Queries the gRPC server for the information of a specific block and its transactions.
+      } --  ^Queries the gRPC server for the pending updates in a specific block.
+  | GetBlockSpecialEvents
+      { legacyBlockHash :: !(Maybe Text)
+      } --  ^Queries the gRPC server for the special events in a specific block.
+  | GetBlockChainParameters
+      { legacyBlockHash :: !(Maybe Text)
+      } --  ^Queries the gRPC server for the chain parameters in a specific block.
+  | GetBlockFinalizationSummary
+      { legacyBlockHash :: !(Maybe Text)
+      } --  ^Queries the gRPC server for the finalization summary in a specific block.
   | GetBlocksAtHeight
       { legacyBlockHeight :: !BlockHeight,
         legacyFromGenesisIndex :: !(Maybe GenesisIndex),
@@ -121,7 +130,10 @@ legacyProgramOptions =
      getTransactionStatusCommand <>
      getConsensusInfoCommand <>
      getBlockInfoCommand <>
-     getBlockSummaryCommand <>
+     getBlockPendingUpdatesCommand <>
+     getBlockSpecialEventsCommand <>
+     getBlockChainParametersCommand <>
+     getBlockFinalizationSummaryCommand <>
      getBlocksAtHeightCommand <>
      getAccountListCommand <>
      getInstancesCommand <>
@@ -231,7 +243,7 @@ getBlockInfoCommand =
         optional (strArgument (metavar "BLOCK-HASH" <> help "Hash of the block to query"))
        )
        (progDesc "Query the gRPC server for a specific block."))
-
+{- VH/FIXME: Removed, document in FP and changelog.
 getBlockSummaryCommand :: Mod CommandFields LegacyCmd
 getBlockSummaryCommand =
   command
@@ -241,6 +253,46 @@ getBlockSummaryCommand =
         optional (strArgument (metavar "BLOCK-HASH" <> help "Hash of the block to query"))
        )
        (progDesc "Query the gRPC server for a specific block and its transactions."))
+-}
+getBlockPendingUpdatesCommand :: Mod CommandFields LegacyCmd
+getBlockPendingUpdatesCommand =
+  command
+    "GetBlockPendingUpdates"
+    (info
+       (GetBlockPendingUpdates <$>
+        optional (strArgument (metavar "BLOCK-HASH" <> help "Hash of the block to query"))
+       )
+       (progDesc "Query the gRPC server for the pending updates in a specific block."))
+
+getBlockSpecialEventsCommand :: Mod CommandFields LegacyCmd
+getBlockSpecialEventsCommand =
+  command
+    "GetBlockSpecialEvents"
+    (info
+       (GetBlockSpecialEvents <$>
+        optional (strArgument (metavar "BLOCK-HASH" <> help "Hash of the block to query"))
+       )
+       (progDesc "Query the gRPC server for the special events in a specific block."))
+
+getBlockChainParametersCommand :: Mod CommandFields LegacyCmd
+getBlockChainParametersCommand =
+  command
+    "GetBlockChainParameters"
+    (info
+       (GetBlockChainParameters <$>
+        optional (strArgument (metavar "BLOCK-HASH" <> help "Hash of the block to query"))
+       )
+       (progDesc "Query the gRPC server for the special events in a specific block."))
+
+getBlockFinalizationSummaryCommand :: Mod CommandFields LegacyCmd
+getBlockFinalizationSummaryCommand =
+  command
+    "GetBlockFinalizationSummary"
+    (info
+       (GetBlockFinalizationSummary <$>
+        optional (strArgument (metavar "BLOCK-HASH" <> help "Hash of the block to query"))
+       )
+       (progDesc "Query the gRPC server for the finalization summary in a specific block."))
 
 getBlocksAtHeightCommand :: Mod CommandFields LegacyCmd
 getBlocksAtHeightCommand =

--- a/src/Concordium/Client/LegacyCommands.hs
+++ b/src/Concordium/Client/LegacyCommands.hs
@@ -15,12 +15,6 @@ data LegacyCmd
   | GetTransactionStatus
       { legacyTransactionHash :: !Text
       } -- ^ Queries the gRPC for the information about the execution of a transaction
-  {- VH/FIXME: These are deprecated, remove and document in FP and changelog. 
-  | GetTransactionStatusInBlock
-      { legacyTransactionHash :: !Text,
-        legacyBlockHash' :: !Text
-      } -- ^ Queries the gRPC for the information about the execution of a transaction
-  -}
   | GetAccountNonFinalized {
       legacyAddress :: !Text
       } -- ^Get non finalized transactions for a given account.
@@ -209,22 +203,6 @@ getTransactionStatusCommand =
        (progDesc
           "Query the gRPC for the information about the execution of a transaction."))
 
-{- VH/FIXME: Document in FP/changelog.
-getTransactionStatusInBlockCommand :: Mod CommandFields LegacyCmd
-getTransactionStatusInBlockCommand =
-  command
-    "GetTransactionStatusInBlock"
-    (info
-       (GetTransactionStatusInBlock <$>
-        strArgument
-          (metavar "TX-HASH" <> help "Hash of the transaction to query for") <*>
-        strArgument
-          (metavar "BLOCK-HASH" <> help "Hash of the block")
-       )
-       (progDesc
-          "Query the gRPC for the information about the execution of a transaction in a specific block."))
--}
-
 getConsensusInfoCommand :: Mod CommandFields LegacyCmd
 getConsensusInfoCommand =
   command
@@ -243,17 +221,7 @@ getBlockInfoCommand =
         optional (strArgument (metavar "BLOCK-HASH" <> help "Hash of the block to query"))
        )
        (progDesc "Query the gRPC server for a specific block."))
-{- VH/FIXME: Removed, document in FP and changelog.
-getBlockSummaryCommand :: Mod CommandFields LegacyCmd
-getBlockSummaryCommand =
-  command
-    "GetBlockSummary"
-    (info
-       (GetBlockSummary <$>
-        optional (strArgument (metavar "BLOCK-HASH" <> help "Hash of the block to query"))
-       )
-       (progDesc "Query the gRPC server for a specific block and its transactions."))
--}
+
 getBlockPendingUpdatesCommand :: Mod CommandFields LegacyCmd
 getBlockPendingUpdatesCommand =
   command
@@ -429,24 +397,6 @@ getModuleListCommand =
         optional (strArgument (metavar "BLOCK-HASH" <> help "Hash of the block to query")))
        (progDesc "Query the gRPC server for the list of modules."))
 
-{- FIXME: These are deprecated; remove and document in FP.
-startBakerCommand :: Mod CommandFields LegacyCmd
-startBakerCommand =
-    command
-     "StartBaker"
-    (info
-       (pure StartBaker)
-       (progDesc "Start the baker."))
-
-stopBakerCommand :: Mod CommandFields LegacyCmd
-stopBakerCommand =
-    command
-     "StopBaker"
-    (info
-       (pure StopBaker)
-       (progDesc "Stop the baker."))
---}
-
 peerConnectCommand :: Mod CommandFields LegacyCmd
 peerConnectCommand =
     command
@@ -499,27 +449,6 @@ unbanNodeCommand =
         strArgument
           (metavar "NODE-IP" <> help "IP of the node to be unbanned"))
        (progDesc "Unban a node."))
-
-{- FIXME: These are deprecated; remove and document in FP.
-
-joinNetworkCommand :: Mod CommandFields LegacyCmd
-joinNetworkCommand =
-    command
-     "JoinNetwork"
-    (info
-       (JoinNetwork <$>
-        argument auto (metavar "NET-ID" <> help "ID of the network"))
-       (progDesc "Join a network."))
-
-leaveNetworkCommand :: Mod CommandFields LegacyCmd
-leaveNetworkCommand =
-    command
-     "LeaveNetwork"
-    (info
-       (LeaveNetwork <$>
-        argument auto (metavar "NET-ID" <> help "ID of the network"))
-       (progDesc "Leave a network."))
--}
 
 getAncestorsCommand :: Mod CommandFields LegacyCmd
 getAncestorsCommand =

--- a/src/Concordium/Client/LegacyCommands.hs
+++ b/src/Concordium/Client/LegacyCommands.hs
@@ -15,10 +15,12 @@ data LegacyCmd
   | GetTransactionStatus
       { legacyTransactionHash :: !Text
       } -- ^ Queries the gRPC for the information about the execution of a transaction
+  {- VH/FIXME: These are deprecated, remove and document in FP and changelog. 
   | GetTransactionStatusInBlock
       { legacyTransactionHash :: !Text,
         legacyBlockHash' :: !Text
       } -- ^ Queries the gRPC for the information about the execution of a transaction
+  -}
   | GetAccountNonFinalized {
       legacyAddress :: !Text
       } -- ^Get non finalized transactions for a given account.
@@ -100,8 +102,8 @@ data LegacyCmd
   | GetBannedPeers
   | Shutdown
   | DumpStart
-    { legacyFilepath :: !Text,
-      legacyRaw :: !Bool
+    { legacyFilepath :: !Text, -- ^ Path of the file to write the dumped packages to
+      legacyRaw :: !Bool -- ^ Dump raw packages if true
     }
   | DumpStop
   | GetIdentityProviders
@@ -117,7 +119,6 @@ legacyProgramOptions =
   hsubparser
     (sendTransactionCommand <>
      getTransactionStatusCommand <>
-     getTransactionStatusInBlockCommand <>
      getConsensusInfoCommand <>
      getBlockInfoCommand <>
      getBlockSummaryCommand <>
@@ -196,6 +197,7 @@ getTransactionStatusCommand =
        (progDesc
           "Query the gRPC for the information about the execution of a transaction."))
 
+{- VH/FIXME: Document in FP/changelog.
 getTransactionStatusInBlockCommand :: Mod CommandFields LegacyCmd
 getTransactionStatusInBlockCommand =
   command
@@ -209,6 +211,7 @@ getTransactionStatusInBlockCommand =
        )
        (progDesc
           "Query the gRPC for the information about the execution of a transaction in a specific block."))
+-}
 
 getConsensusInfoCommand :: Mod CommandFields LegacyCmd
 getConsensusInfoCommand =
@@ -510,13 +513,8 @@ dumpStartCommand =
     (info
        (DumpStart <$> 
         strArgument
-          (metavar "FILE" <> help "Path to the file to write the dumped packages to") <*>
-        argument
-          auto
-          (metavar "RAW" <>
-           value False <>
-           showDefault <>
-           help "Dump raw packages"))
+          (metavar "FILE" <> help "Path of the file to write the dumped packages to") <*>
+          flag False True (long "restrict" <> help "Dump raw packages"))
        (progDesc "Start dumping the packages."))
 
 dumpStopCommand :: Mod CommandFields LegacyCmd

--- a/src/Concordium/Client/Runner.hs
+++ b/src/Concordium/Client/Runner.hs
@@ -3721,15 +3721,16 @@ processLegacyCmd action backend =
       when (recurse && Queries.biBlockHeight bi /= 0)
         (printBlockInfos recurse $ Given (Queries.biBlockParent bi))
 
-    -- |Add a pending V0 chain parameter update to its appropriate queue.
+    -- |Add a pending chain parameter update to its appropriate queue in an
+    -- @PendingUpdates 'ChainParametersV0@ instance.
     -- The output is either a @Left@ wrapping a @PendingUpdates@ instance with
     -- the update added to its appropriate queue, or a @Right@ wrapping a pair
     -- of an @AccountAddress@ and a callback which takes an @AccountIndex@ and
-    -- returns the@PendingUpdates@ instance with the update added to its appropriate
-    -- queue. The address can then be converted to its corresponding index and
-    -- fed to the closure to get the @PendingUpdates@ instance. This is due to API
-    -- returning an account address, while the native datatype uses use an account
-    -- index.
+    -- returns the @PendingUpdates@ instance with the update added. The address
+    -- can then be converted to its corresponding index and fed to the closure
+    -- to get the @PendingUpdates@ instance. This is due to API returning an
+    -- account address, while the native datatype uses use an account index.
+    -- Fails if the @PendingUpdate@ is a V1 chain parameter update.
     addPendingUpdateV0 :: (MonadFail m)
         => PendingUpdate -- |The pending update.
         -> PendingUpdates 'Types.ChainParametersV0 -- |The update queues.
@@ -3764,15 +3765,16 @@ processLegacyCmd action backend =
         enqueueM :: (Monad m) => ASetter (PendingUpdates 'Types.ChainParametersV0) a (UpdateQueue e) (UpdateQueue e) -> e -> m (Either a b)
         enqueueM l v = return . Left $ enqueue' puEffectiveTime updates l v
 
-    -- |Add a pending V1 chain parameter update to its appropriate queue.
+    -- |Add a pending chain parameter update to its appropriate queue in an
+    -- @PendingUpdates 'ChainParametersV1@ instance.
     -- The output is either a @Left@ wrapping a @PendingUpdates@ instance with
     -- the update added to its appropriate queue, or a @Right@ wrapping a pair
     -- of an @AccountAddress@ and a callback which takes an @AccountIndex@ and
-    -- returns the@PendingUpdates@ instance with the update added to its appropriate
-    -- queue. The address can then be converted to its corresponding index and
-    -- fed to the closure to get the @PendingUpdates@ instance. This is due to API
-    -- returning an account address, while the native datatype uses use an account
-    -- index.
+    -- returns the @PendingUpdates@ instance with the update added. The address
+    -- can then be converted to its corresponding index and fed to the closure
+    -- to get the @PendingUpdates@ instance. This is due to API returning an
+    -- account address, while the native datatype uses use an account index.
+    -- Fails if the @PendingUpdate@ is a V0 chain parameter update.
     addPendingUpdateV1 :: (MonadFail m)
         => PendingUpdate -- |The pending update.
         -> PendingUpdates 'Types.ChainParametersV1 -- |The update queues.

--- a/src/Concordium/Client/Runner.hs
+++ b/src/Concordium/Client/Runner.hs
@@ -3702,7 +3702,7 @@ data PeerData = PeerData {
   peerList      :: PeerListResponse
   }
 
-printPeerData :: MonadIO m => Bool -> Queries.PeersInfo -> Queries.NodeInfo -> m ()
+printPeerData :: MonadIO m => Bool -> [Queries.PeerInfo] -> Queries.NodeInfo -> m ()
 printPeerData bootstrapper pInfos Queries.NodeInfo{..} =
   let Queries.NetworkInfo{..} = networkInfo
       -- Filter bootstrappers.

--- a/src/Concordium/Client/Runner.hs
+++ b/src/Concordium/Client/Runner.hs
@@ -3524,6 +3524,9 @@ processLegacyCmd action backend =
       withClient backend $
         getBlockItemsV2 t >>=
         getResponseValueOrFail'' >>=
+        -- ↓ FIXME: The below changes the client output.
+        --          Should this be documented or changed
+        --          to a different output?
         (\case
               Queries.Received ->
                 fail "Transaction received, but not present in any block."

--- a/src/Concordium/Client/Runner.hs
+++ b/src/Concordium/Client/Runner.hs
@@ -3732,7 +3732,7 @@ processLegacyCmd action backend =
     -- returns the @PendingUpdates@ instance with the update added. The address
     -- can then be converted to its corresponding index and fed to the closure
     -- to get the @PendingUpdates@ instance. This is due to API returning an
-    -- account address, while the native datatype uses use an account index.
+    -- account address, while the native datatype uses an account index.
     -- Fails if the @PendingUpdate@ is a V1 chain parameter update.
     addPendingUpdateV0 :: (MonadFail m)
         => PendingUpdate -- |The pending update.
@@ -3776,7 +3776,7 @@ processLegacyCmd action backend =
     -- returns the @PendingUpdates@ instance with the update added. The address
     -- can then be converted to its corresponding index and fed to the closure
     -- to get the @PendingUpdates@ instance. This is due to API returning an
-    -- account address, while the native datatype uses use an account index.
+    -- account address, while the native datatype uses an account index.
     -- Fails if the @PendingUpdate@ is a V0 chain parameter update.
     addPendingUpdateV1 :: (MonadFail m)
         => PendingUpdate -- |The pending update.

--- a/src/Concordium/Client/Runner.hs
+++ b/src/Concordium/Client/Runner.hs
@@ -3501,10 +3501,13 @@ processLegacyCmd action backend =
       withClient backend $
         getBlocksAtHeightV2
         -- ↓ FIXME: Verify that this is correct in particular.
-        (case (gen, restr) of
-          (Just g, Just _) -> Relative g height True
-          (Just g, Nothing) -> Relative g height False
-          (Nothing, _) -> Absolute (Types.AbsoluteBlockHeight $ Types.theBlockHeight height)) >>=
+          (case (gen, restr) of
+            (Just g, Just _) ->
+              Relative g height True
+            (Just g, Nothing) ->
+              Relative g height False
+            (Nothing, _) ->
+              Absolute (Types.AbsoluteBlockHeight $ Types.theBlockHeight height)) >>=
         printResponseValueAsJSON'
     GetAccountList block ->
       withClient backend $
@@ -3581,7 +3584,7 @@ processLegacyCmd action backend =
         (case eitherDecode ctx of
           Left err -> fail err
           Right c -> invokeInstanceV2 b c) >>=
-            printResponseValueAsJSON'
+          printResponseValueAsJSON'
     GetPoolStatus pool block ->
       withClient backend $ do
         b <- readOrFailM Best block

--- a/src/Concordium/Client/Runner.hs
+++ b/src/Concordium/Client/Runner.hs
@@ -3706,7 +3706,7 @@ printPeerData :: MonadIO m => Bool -> [Queries.PeerInfo] -> Queries.NodeInfo -> 
 printPeerData bootstrapper pInfos Queries.NodeInfo{..} =
   let Queries.NetworkInfo{..} = networkInfo
       -- Filter bootstrappers.
-      pInfos' = filter (\p -> bootstrapper || Queries.consensusInfo p == Queries.Bootstrapper) pInfos
+      pInfos' = filter (\p -> bootstrapper || Queries.consensusInfo p /= Queries.Bootstrapper) pInfos
   in
   liftIO $ do
       putStrLn $ "Total packets sent: " ++ show peerTotalSent

--- a/src/Concordium/Client/Runner.hs
+++ b/src/Concordium/Client/Runner.hs
@@ -3447,8 +3447,6 @@ processIdentityShowCmd action backend =
 processLegacyCmd :: LegacyCmd -> Backend -> IO ()
 processLegacyCmd action backend =
   case action of
-    -- ↓ FIXME: This should be verified in particular, 
-    --          I am not sure how to test it.
     SendTransaction fname nid -> do
       source <- handleReadFile BSL.readFile fname
       t <- withClient backend $ processTransaction source nid

--- a/src/Concordium/Client/Runner.hs
+++ b/src/Concordium/Client/Runner.hs
@@ -3775,8 +3775,8 @@ printNodeInfo Queries.NodeInfo{..} = liftIO $
       putStrLn $ "Baker running: " ++ show (getBakerRunning details)
       putStrLn $ "Consensus running: " ++ show (getConsensusRunning details)
       putStrLn $ "Consensus type: " ++ getConsensusType details
-      putStrLn $ "Baker committee member: " ++ show (getBakerCommitteeMember details)
-      putStrLn $ "Finalization committee member: " ++ show (getFinalizerCommitteeMember details)
+      putStrLn $ "Baker committee member: " ++ getBakerCommitteeMember details
+      putStrLn $ "Finalization committee member: " ++ getFinalizerCommitteeMember details
   where showNodeType =
           \case Queries.NodeBootstrapper -> "Bootstrapper"
                 Queries.NodeNotRunning -> "Node"
@@ -3809,7 +3809,7 @@ printNodeInfo Queries.NodeInfo{..} = liftIO $
                 Queries.NodeActive (Queries.BakerConsensusInfo _ (Queries.PassiveBaker Queries.AddedButNotActiveInCommittee)) ->
                   show False
                 Queries.NodeActive (Queries.BakerConsensusInfo _ (Queries.PassiveBaker Queries.AddedButWrongKeys)) ->
-                  "show False"
+                  show False
                 Queries.NodeActive (Queries.BakerConsensusInfo bId Queries.ActiveBakerCommitteeInfo) ->
                   "True, in current baker committee with baker ID '" <> show bId <> "'."
                 Queries.NodeActive (Queries.BakerConsensusInfo bId Queries.ActiveFinalizerCommitteeInfo) ->


### PR DESCRIPTION
## Purpose

Migrate the `raw` family of commands to use the GRPC V2 API; this is part of migrating the client to the GRPC V2 API feature.

Depends on https://github.com/Concordium/concordium-base/pull/317

## Changes
Implement helpers for gluing V2 API and `raw` commands of the client:

### Tasks
- Wrap output of `fromProto` in `Either` rather than `Maybe`. 
- Migrate `raw` commands.
- Misc. fixes and better comments in GRPC V2 `FromProto` instances.

### Client interface changes
- Remove `raw` client commands `startBaker`, `stopBaker`, `joinNetwork`, `leaveNetwork`.
- Remove node ID input from `BanNode` and `UnbanNode`.
- Add dump file path and `raw` flag to `DumpStart`.
- Change output of `GetBannedPeers` to display JSON instead of using leveraging `show`, e.g.

```
Right {peer_type: "Node" peers { node_id { value: "*" } ip { value: "10.10.10.10" } catchup_status: PENDING } peers { node_id { value: "*" } ip { value: "192.168.0.1" } catchup_status: PENDING } peers { node_id { value: "*" } ip { value: "192.168.0.100" } catchup_status: PENDING } peers { node_id { value: "*" } ip { value: "192.168.1.1" } catchup_status: PENDING } peers { node_id { value: "*" } ip { value: "192.168.1.100" } catchup_status: PENDING }}
```

to:

```
[
    "10.10.10.10",
    "192.168.0.1",
    "192.168.0.100",
    "192.168.1.1",
    "192.168.1.100"
]
```

- Change output of `GetPeerUptime` to display a `Word64` instead of `Maybe Word64`.
- Output of `GetTransactionStatusInBlock` when no transaction summary is present in response.

## Checklist
- [ ] My code follows the style of this project.
- [ ] The code compiles without warnings.
- [ ] I have performed a self-review of the changes.
- [ ] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [ ] (If necessary) I have updated the CHANGELOG.