### PR TITLE
Fix buffering of streaming calls by updating the dependency.

### DIFF
--- a/stack.yaml
+++ b/stack.yaml
@@ -45,7 +45,7 @@ extra-deps:
   commit: 8087dfd416118064934affb35caab811a8a70233
 
 - github: Concordium/http2-grpc-haskell
-  commit: 7f4f4955cd64d867b9fda951600a445653f5b098
+  commit: d3d7a3413ccf4ca899602df8ef8e99601024938a
   subdirs:
     - http2-client-grpc
     - http2-grpc-proto-lens

--- a/stack.yaml
+++ b/stack.yaml
@@ -45,7 +45,7 @@ extra-deps:
   commit: 8087dfd416118064934affb35caab811a8a70233
 
 - github: Concordium/http2-grpc-haskell
-  commit: d3d7a3413ccf4ca899602df8ef8e99601024938a
+  commit: d79454adc7234908a05b3b5339b48ceaca23ffd9
   subdirs:
     - http2-client-grpc
     - http2-grpc-proto-lens


### PR DESCRIPTION
## Purpose

Fix delays in streaming calls due to uncredited connection window updates.

Depends on 
- [x] https://github.com/Concordium/http2-grpc-haskell/pull/4

Fixes #213 

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [x] (If necessary) I have updated the CHANGELOG.
