### PR TITLE
Migrate family of `block` client commands to GRPC V2.

### DIFF
--- a/src/Concordium/Client/Runner.hs
+++ b/src/Concordium/Client/Runner.hs
@@ -2441,11 +2441,16 @@ processBlockCmd :: BlockCmd -> Verbose -> Backend -> IO ()
 processBlockCmd action _ backend =
   case action of
     BlockShow b -> do
-      when (maybe False (isNothing . parseTransactionHash) b) $
-        logFatal [printf "invalid block hash '%s'" (fromJust b)]
-
-      v <- withClientJson backend $ fmap grpcResponseVal <$> withBestBlockHash b getBlockInfo
-      runPrinter $ printBlockInfo v
+      bHash <- readBlockHashOrDefault Best b
+      withClient backend $
+        getBlockInfoV2 bHash>>=
+          getResponseValueOrFail >>=
+            -- VH/FIXME: Output changes slightly due to V2 API - document?
+            -- Specifically `printBlockInfo` prints `Block not found` when
+            -- its input is @Nothing@, which is never the case here.
+            -- Instead, `Error: A GRPC error occurred: gRPC error: block not found.``
+            -- is printed.
+            runPrinter . printBlockInfo . Just
 
 -- |Generate a fresh set of baker keys.
 generateBakerKeys :: Maybe Types.BakerId -> IO BakerKeys


### PR DESCRIPTION
## Purpose

Migrate the `block` family of commands to use the GRPC V2 API; this is part of migrating the client to the GRPC V2 API feature.

Depends on:

https://github.com/Concordium/concordium-base/pull/317

https://github.com/Concordium/concordium-client/pull/215

## Changes
Implement helpers for gluing V2 API and `block` commands of the client:

### Tasks
- Migrate `block show` command.

### Client interface changes
- Different messages in case of API server errors and response conversion/invariant errors.

## Checklist
- [X] My code follows the style of this project.
- [X] The code compiles without warnings.
- [X] I have performed a self-review of the changes.
- [X] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [ ] (If necessary) I have updated the CHANGELOG.