### PR TITLE
Remove proto-lens-setup from the build step.

### DIFF
--- a/Setup.hs
+++ b/Setup.hs
@@ -1,5 +1,3 @@
-import Data.ProtoLens.Setup
-
 import Distribution.PackageDescription
 import Distribution.Simple
 import Distribution.Simple.LocalBuildInfo
@@ -20,7 +18,7 @@ autoConfHook desc flags = do
             in confHook simpleUserHooks desc extraFlags
     _ -> confHook simpleUserHooks desc flags
 
-main = defaultMainWithHooks $ generatingProtos "deps/concordium-base/concordium-grpc-api/v2" simpleUserHooks
+main = defaultMainWithHooks simpleUserHooks
   {
     confHook = autoConfHook
   }

--- a/concordium-client.cabal
+++ b/concordium-client.cabal
@@ -1,6 +1,6 @@
 cabal-version: 1.24
 
--- This file has been generated from package.yaml by hpack version 0.35.0.
+-- This file has been generated from package.yaml by hpack version 0.35.1.
 --
 -- see: https://github.com/sol/hpack
 
@@ -27,7 +27,6 @@ custom-setup
   setup-depends:
       Cabal
     , base
-    , proto-lens-setup ==0.4.*
 
 flag static
   description: Use static linking.
@@ -100,7 +99,6 @@ library
     , pretty
     , proto-lens ==0.7.*
     , proto-lens-protobuf-types ==0.7.*
-    , proto-lens-runtime ==0.7.*
     , random
     , scientific
     , split

--- a/package.yaml
+++ b/package.yaml
@@ -15,7 +15,6 @@ custom-setup:
   dependencies:
     - base
     - Cabal
-    - proto-lens-setup == 0.4.*
 
 default-extensions:
 - OverloadedStrings
@@ -88,7 +87,6 @@ library:
     - pretty
     - proto-lens == 0.7.*
     - proto-lens-protobuf-types == 0.7.*
-    - proto-lens-runtime == 0.7.*
     - microlens-platform
     - transformers
     - uri-encode >= 1.5


### PR DESCRIPTION
## Purpose

The proto files are all generated in concordium-base now.


## Checklist

- [ ] My code follows the style of this project.
- [ ] The code compiles without warnings.
- [ ] I have performed a self-review of the changes.
- [ ] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [ ] (If necessary) I have updated the CHANGELOG.