### PR TITLE
Remove code-leftovers when printing values wrapped in `Conditionally` in `consensus show-chain-parameters`.

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -3,7 +3,8 @@
 ## Unreleased
 
 - Fix a bug that caused another code-leftover to be displayed in the finalization proof
-  line of the gas rewards section of the `consensus show-chain-parameters` output.
+  line of the gas rewards section of the `consensus show-chain-parameters` output. This
+  is only when the queried chain runs protocol version 6 or lower.
 
 ## 5.1.1
 

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -4,7 +4,7 @@
 
 - Fix a bug that caused another code-leftover to be displayed in the finalization proof
   line of the gas rewards section of the `consensus show-chain-parameters` output. This
-  is only relevant when the queried chain runs protocol version 6 or lower.
+  is only relevant when the queried chain runs protocol version 6.
 
 ## 5.1.1
 

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -4,7 +4,7 @@
 
 - Fix a bug that caused another code-leftover to be displayed in the finalization proof
   line of the gas rewards section of the `consensus show-chain-parameters` output. This
-  is only when the queried chain runs protocol version 6 or lower.
+  is only relevant when the queried chain runs protocol version 6 or lower.
 
 ## 5.1.1
 

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -2,7 +2,7 @@
 
 ## Unreleased
 
-- Fix another a bug that caused leftover code to be displayed in the finalization proof
+- Fix a bug that caused another code-leftover to be displayed in the finalization proof
   line of the gas rewards section of the `consensus show-chain-parameters` output.
 
 ## 5.1.1

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Fix another a bug that caused leftover code to be displayed in the finalization proof
+  line of the gas rewards section of the `consensus show-chain-parameters` output.
 
 ## 5.1.1
 

--- a/src/Concordium/Client/Output.hs
+++ b/src/Concordium/Client/Output.hs
@@ -1074,7 +1074,7 @@ printChainParametersV0 ChainParameters {..} = tell [
   [i|     * fraction for the GAS account: #{_cpRewardParameters ^. tfdGASAccount}|],
   [i|  + GAS account distribution:|],
   [i|     * baking a block: #{_cpRewardParameters ^. gasBaker}|],
-  [i|     * adding a finalization proof: |] <> showConditionally (_cpRewardParameters ^. gasFinalizationProof),
+  [i|     * adding a finalization proof: #{showConditionally (_cpRewardParameters ^. gasFinalizationProof)}|],
   [i|     * adding a credential deployment: #{_cpRewardParameters ^. gasAccountCreation}|],
   [i|     * adding a chain update: #{_cpRewardParameters ^. gasChainUpdate}|],
   "",

--- a/src/Concordium/Client/Output.hs
+++ b/src/Concordium/Client/Output.hs
@@ -1120,7 +1120,7 @@ printChainParametersV1 ChainParameters {..} = tell [
   [i|     * GAS account: #{_cpRewardParameters ^. tfdGASAccount}|],
   [i|  + GAS rewards:|],
   [i|     * baking a block: #{_cpRewardParameters ^. gasBaker}|],
-  [i|     * adding a finalization proof: |] <> showConditionally (_cpRewardParameters ^. gasFinalizationProof),
+  [i|     * adding a finalization proof: #{showConditionally (_cpRewardParameters ^. gasFinalizationProof)}|],
   [i|     * adding a credential deployment: #{_cpRewardParameters ^. gasAccountCreation}|],
   [i|     * adding a chain update: #{_cpRewardParameters ^. gasChainUpdate}|],
   "",

--- a/src/Concordium/Client/Output.hs
+++ b/src/Concordium/Client/Output.hs
@@ -20,7 +20,7 @@ import Concordium.Client.Utils(durationToText)
 import Concordium.Client.Types.TransactionStatus
 import Concordium.Common.Version
 import Concordium.ID.Parameters
-import qualified Concordium.Types.Conditionally as Types
+import qualified Concordium.Types.Conditionally()
 import qualified Concordium.Types as Types
 import qualified Concordium.Types.Accounts as Types
 import qualified Concordium.Types.Accounts.Releases as Types
@@ -1074,7 +1074,7 @@ printChainParametersV0 ChainParameters {..} = tell [
   [i|     * fraction for the GAS account: #{_cpRewardParameters ^. tfdGASAccount}|],
   [i|  + GAS account distribution:|],
   [i|     * baking a block: #{_cpRewardParameters ^. gasBaker}|],
-  [i|     * adding a finalization proof: #{Types.uncond $ _cpRewardParameters ^. gasFinalizationProof}|],
+  [i|     * adding a finalization proof: |] <> showConditionally (_cpRewardParameters ^. gasFinalizationProof),
   [i|     * adding a credential deployment: #{_cpRewardParameters ^. gasAccountCreation}|],
   [i|     * adding a chain update: #{_cpRewardParameters ^. gasChainUpdate}|],
   "",
@@ -1120,7 +1120,7 @@ printChainParametersV1 ChainParameters {..} = tell [
   [i|     * GAS account: #{_cpRewardParameters ^. tfdGASAccount}|],
   [i|  + GAS rewards:|],
   [i|     * baking a block: #{_cpRewardParameters ^. gasBaker}|],
-  [i|     * adding a finalization proof: #{Types.uncond $ _cpRewardParameters ^. gasFinalizationProof}|],
+  [i|     * adding a finalization proof: |] <> showConditionally (_cpRewardParameters ^. gasFinalizationProof),
   [i|     * adding a credential deployment: #{_cpRewardParameters ^. gasAccountCreation}|],
   [i|     * adding a chain update: #{_cpRewardParameters ^. gasChainUpdate}|],
   "",
@@ -1168,7 +1168,7 @@ printChainParametersV2 ChainParameters {..} = tell [
   [i|     * GAS account: #{_cpRewardParameters ^. tfdGASAccount}|],
   [i|  + GAS rewards:|],
   [i|     * baking a block: #{_cpRewardParameters ^. gasBaker}|],
-  [i|     * adding a finalization proof: #{_cpRewardParameters ^. gasFinalizationProof}|],
+  [i|     * adding a finalization proof: |] <> showConditionally (_cpRewardParameters ^. gasFinalizationProof),
   [i|     * adding a credential deployment: #{_cpRewardParameters ^. gasAccountCreation}|],
   [i|     * adding a chain update: #{_cpRewardParameters ^. gasChainUpdate}|],
   "",
@@ -1342,3 +1342,8 @@ showYesNo = bool "no" "yes"
 -- |Unwrap a list from within `Maybe`. `Nothing` becomes an empty list.
 unwrapMaybeList :: Maybe [a] -> [a]
 unwrapMaybeList = concat
+
+-- |Show a value wrapped in a @Conditionally@.
+showConditionally :: (Show a) => Conditionally b a -> String
+showConditionally (CFalse) = "N/A"
+showConditionally (CTrue v) = show v


### PR DESCRIPTION
## Purpose

Fixes https://github.com/Concordium/concordium-client/issues/246

## Changes

Add function `showConditionally` and use it for printing types wrapped in `Conditionally`. 

## Checklist

- [X] My code follows the style of this project.
- [X] The code compiles without warnings.
- [X] I have performed a self-review of the changes.
- [X] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [X] (If necessary) I have updated the CHANGELOG.