### PR TITLE
Upgrade tooling

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -31,8 +31,8 @@ on:
   workflow_dispatch: # allow manual trigger
 
 env:
-  RUST: 1.62
-  GHC: 9.2.5
+  RUST: 1.68
+  GHC: 9.2.7
 
 jobs:
   concordium-client-build-and-test:

--- a/README.md
+++ b/README.md
@@ -50,14 +50,14 @@ To build the tool from source, you need the following prerequisites:
     - Unix: `curl -sSL https://get.haskellstack.org/ | sh`
     - Windows: [Follow the Stack install guide](https://docs.haskellstack.org/en/stable/install_and_upgrade/).
 
-- Install Rust version 1.62+:
+- Install Rust version 1.68+:
   - Unix: `curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh`
   - Windows: [Follow the Rust install
      guide](https://www.rust-lang.org/tools/install)
     - Use the `x86_64-pc-windows-gnu` toolchain by choosing it during
        installation or by running `rustup toolchain default
        stable-x86_64-pc-windows-gnu`.
-  - *Recommended after installing: Set the default Rust version to 1.62 by running `rustup default 1.62`*.
+  - *Recommended after installing: Set the default Rust version to 1.68 by running `rustup default 1.68`*.
 
 - Install the [protoc](https://github.com/google/proto-lens/blob/master/docs/installing-protoc.md) tool for generating protobuf files:
   - MacOS: `brew install protobuf`

--- a/scripts/distributables/linux-concordium-client.Jenkinsfile
+++ b/scripts/distributables/linux-concordium-client.Jenkinsfile
@@ -1,7 +1,7 @@
 pipeline {
     agent any
     environment {
-        GHC_VERSION = '9.2.5'
+        GHC_VERSION = '9.2.7'
         VERSION = sh(
             returnStdout: true, 
             script: '''\

--- a/scripts/distributables/linux-distributable-concordium-client.Dockerfile
+++ b/scripts/distributables/linux-distributable-concordium-client.Dockerfile
@@ -7,10 +7,10 @@ COPY . /build
 
 RUN apk add perl g++ make protoc ncurses ncurses-dev zlib zlib-static zlib-dev git wget postgresql-dev gmp-dev gmp
 
-ARG RUST_VERSION=1.62
+ARG RUST_VERSION=1.68
 RUN wget -qO - https://sh.rustup.rs | sh -s -- --profile minimal --default-toolchain ${RUST_VERSION} -y
 
-ARG GHC_VERSION=9.2.5
+ARG GHC_VERSION=9.2.7
 RUN wget -q https://s3-eu-west-1.amazonaws.com/static-libraries.concordium.com/ghc-${GHC_VERSION}-x86_64-unknown-linux-integer-gmp.tar.xz && \
         tar -xf ghc-${GHC_VERSION}-x86_64-unknown-linux-integer-gmp.tar.xz && \
         cd ghc-${GHC_VERSION}-x86_64-unknown-linux && \

--- a/scripts/distributables/macos-concordium-client.Jenkinsfile
+++ b/scripts/distributables/macos-concordium-client.Jenkinsfile
@@ -1,8 +1,8 @@
 pipeline {
     agent { label 'jenkins-worker' }
     environment {
-        GHC_VERSION = '9.2.5'
-        RUST_VERSION = '1.62'
+        GHC_VERSION = '9.2.7'
+        RUST_VERSION = '1.68'
         VERSION = sh(
             returnStdout: true,
             script: '''\

--- a/scripts/distributables/windows-build.md
+++ b/scripts/distributables/windows-build.md
@@ -104,7 +104,7 @@ The following components are written in Rust:
 Install [Rustup](https://www.rust-lang.org/tools/install) to be able to compile those:
 Customize installation:
 - triple: `x64_64-pc-windows-gnu`
-- toolchain: `1.62`
+- toolchain: `1.68`
 
 Add binaries to `PATH`:
 
@@ -115,7 +115,7 @@ echo 'PATH=/c/Users/$USER/.cargo/bin:$PATH' >>~/.bash_profile
 Install correct toolchain if it wasn't done during install:
 
 ```sh
-rustup default 1.62-x86_64-pc-windows-gnu
+rustup default 1.68-x86_64-pc-windows-gnu
 ```
 
 #### Protobuf

--- a/scripts/distributables/windows-concordium-client.Jenkinsfile
+++ b/scripts/distributables/windows-concordium-client.Jenkinsfile
@@ -4,7 +4,7 @@ pipeline {
     stages {
         stage('build') {
             environment {
-                GHC_VERSION = '9.2.5'
+                GHC_VERSION = '9.2.7'
                 BASE_OUTFILE = 's3://distribution.concordium.software/tools/windows/concordium-client'
             }
             steps {
@@ -22,7 +22,7 @@ pipeline {
                     fi    
 
                     # Ensure correct rust env
-                    rustup default 1.62-x86_64-pc-windows-gnu
+                    rustup default 1.68-x86_64-pc-windows-gnu
 
                     # Build project
                     stack build --force-dirty

--- a/stack.linux-static.yaml
+++ b/stack.linux-static.yaml
@@ -1,4 +1,4 @@
-resolver: lts-20.4
+resolver: lts-20.16
 
 packages:
 - .
@@ -6,10 +6,10 @@ packages:
 extra-deps:
 # http2-client was never included in stackage
 - github: Concordium/http2-client
-  commit: 8087dfd416118064934affb35caab811a8a70233
+  commit: 4e9058db74e7a27dee0c92c4a754086e8a45a592
 
 - github: Concordium/http2-grpc-haskell
-  commit: 7f4f4955cd64d867b9fda951600a445653f5b098
+  commit: a4a0a31d44f754bf61868552ee5b256d94eed4de
   subdirs:
     - http2-client-grpc
     - http2-grpc-proto-lens

--- a/stack.yaml
+++ b/stack.yaml
@@ -17,7 +17,7 @@
 #
 # resolver: ./custom-snapshot.yaml
 # resolver: https://example.com/snapshots/2018-01-01.yaml
-resolver: lts-20.4
+resolver: lts-20.16
 
 # User packages to be built.
 # Various formats can be used as shown in the example below.
@@ -42,10 +42,10 @@ packages:
 extra-deps:
 # http2-client was never included in stackage
 - github: Concordium/http2-client
-  commit: 8087dfd416118064934affb35caab811a8a70233
+  commit: 4e9058db74e7a27dee0c92c4a754086e8a45a592
 
 - github: Concordium/http2-grpc-haskell
-  commit: d79454adc7234908a05b3b5339b48ceaca23ffd9
+  commit: a4a0a31d44f754bf61868552ee5b256d94eed4de
   subdirs:
     - http2-client-grpc
     - http2-grpc-proto-lens


### PR DESCRIPTION
## Purpose

Resolves https://github.com/Concordium/concordium-client/issues/248

Depends on
https://github.com/Concordium/concordium-base/pull/353
https://github.com/Concordium/http2-client/pull/5
https://github.com/Concordium/http2-grpc-haskell/pull/5

## Changes

- Upgrade the stackage snapshot to `lts-20.16` and GHC to `9.2.7`.
- Bump `rustc` to `1.68`.

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [x] (If necessary) I have updated the CHANGELOG.