### PR TITLE
Fix a stray `CTrue` output in show chain parameters.

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Remove a stray `CTrue` in output of `consensus show-chain-parameters`.
+
 ## 5.2.0
 
 - Fix a bug that caused another code-leftover to be displayed in the finalization proof

--- a/src/Concordium/Client/Output.hs
+++ b/src/Concordium/Client/Output.hs
@@ -20,7 +20,6 @@ import Concordium.Client.Utils(durationToText)
 import Concordium.Client.Types.TransactionStatus
 import Concordium.Common.Version
 import Concordium.ID.Parameters
-import qualified Concordium.Types.Conditionally()
 import qualified Concordium.Types as Types
 import qualified Concordium.Types.Accounts as Types
 import qualified Concordium.Types.Accounts.Releases as Types
@@ -1065,7 +1064,7 @@ printChainParametersV0 ChainParameters {..} = tell [
   [i|  + microCCD per EUR rate: #{showExchangeRate (_erMicroGTUPerEuro _cpExchangeRates)}|],
   "",
   [i|\# Parameters that affect rewards distribution:|],
-  [i|  + mint rate per slot: #{_cpRewardParameters ^. mdMintPerSlot}|],
+  [i|  + mint rate per slot: #{_cpRewardParameters ^. (mdMintPerSlot . unconditionally)}|],
   [i|  + mint distribution:|],
   [i|     * baking reward: #{_cpRewardParameters ^. mdBakingReward}|],
   [i|     * finalization reward: #{_cpRewardParameters ^. mdFinalizationReward}|],


### PR DESCRIPTION
## Purpose

Fixes #254 

## Checklist

- [ ] My code follows the style of this project.
- [ ] The code compiles without warnings.
- [ ] I have performed a self-review of the changes.
- [ ] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [ ] (If necessary) I have updated the CHANGELOG.