### PR TITLE
Bump base add get update seq numbers

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -3,7 +3,8 @@
 ## Unreleased
 
 - Remove a stray `CTrue` in output of `consensus show-chain-parameters`.
-- The client now outputs protocol version as part of raw `GetBlockInfo`.
+- The client now outputs protocol version as part of raw `GetBlockInfo` and
+  `block show` commands.
 - The client needs node version at least 5.4.
 - Add `raw GetNextUpdateSequenceNumbers` subcommand.
 

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Remove a stray `CTrue` in output of `consensus show-chain-parameters`.
+
 ## 5.2.0
 
 - Fix a bug that caused another code-leftover to be displayed in the finalization proof

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -3,6 +3,9 @@
 ## Unreleased
 
 - Remove a stray `CTrue` in output of `consensus show-chain-parameters`.
+- The client now outputs protocol version as part of raw `GetBlockInfo`.
+- The client needs node version at least 5.4.
+- Add `raw GetNextUpdateSequenceNumbers` subcommand.
 
 ## 5.2.0
 

--- a/src/Concordium/Client/GRPC2.hs
+++ b/src/Concordium/Client/GRPC2.hs
@@ -879,6 +879,7 @@ instance FromProto Proto.BlockInfo where
         biTransactionEnergyCost <- fromProto $ bi ^. ProtoFields.transactionsEnergyCost
         let biTransactionsSize = fromIntegral $ bi ^. ProtoFields.transactionsSize
         biBlockStateHash <- fromProto $ bi ^. ProtoFields.stateHash
+        biProtocolVersion <- fromProto $ bi ^. ProtoFields.protocolVersion
         return BlockInfo{..}
 
 instance FromProto Proto.Amount where

--- a/src/Concordium/Client/LegacyCommands.hs
+++ b/src/Concordium/Client/LegacyCommands.hs
@@ -117,6 +117,8 @@ data LegacyCmd
     { legacyBlockHash :: !(Maybe Text) }
   | GetCryptographicParameters
     { legacyBlockHash :: !(Maybe Text) }
+  | GetNextUpdateSequenceNumbers
+    { legacyBlockHash :: !(Maybe Text) }
   deriving (Show)
 
 legacyProgramOptions :: Parser LegacyCmd
@@ -159,7 +161,8 @@ legacyProgramOptions =
      dumpStopCommand <>
      getIdentityProvidersCommand <>
      getAnonymityRevokersCommand <>
-     getCryptographicParametersCommand
+     getCryptographicParametersCommand <>
+     getNextUpdateSequenceNumbersCommand
     )
 
 getPeerDataCommand :: Mod CommandFields LegacyCmd
@@ -329,6 +332,16 @@ getNextAccountNonceCommand =
         strArgument (metavar "ACCOUNT" <> help "Account to be queried about")
        )
        (progDesc "Query the gRPC server for the best guess on the next account nonce."))
+
+getNextUpdateSequenceNumbersCommand :: Mod CommandFields LegacyCmd
+getNextUpdateSequenceNumbersCommand =
+  command
+    "GetNextUpdateSequenceNumbers"
+    (info
+       (GetNextUpdateSequenceNumbers <$>
+        optional (strArgument (metavar "BLOCK-HASH" <> help "Hash of the block to query (default: Query the best block)"))
+       )
+       (progDesc "Query the gRPC server for the next update sequence numbers for all update queues."))
 
 
 getInstanceInfoCommand :: Mod CommandFields LegacyCmd

--- a/src/Concordium/Client/Output.hs
+++ b/src/Concordium/Client/Output.hs
@@ -20,7 +20,6 @@ import Concordium.Client.Utils(durationToText)
 import Concordium.Client.Types.TransactionStatus
 import Concordium.Common.Version
 import Concordium.ID.Parameters
-import qualified Concordium.Types.Conditionally()
 import qualified Concordium.Types as Types
 import qualified Concordium.Types.Accounts as Types
 import qualified Concordium.Types.Accounts.Releases as Types
@@ -1065,7 +1064,7 @@ printChainParametersV0 ChainParameters {..} = tell [
   [i|  + microCCD per EUR rate: #{showExchangeRate (_erMicroGTUPerEuro _cpExchangeRates)}|],
   "",
   [i|\# Parameters that affect rewards distribution:|],
-  [i|  + mint rate per slot: #{_cpRewardParameters ^. mdMintPerSlot}|],
+  [i|  + mint rate per slot: #{_cpRewardParameters ^. (mdMintPerSlot . unconditionally)}|],
   [i|  + mint distribution:|],
   [i|     * baking reward: #{_cpRewardParameters ^. mdBakingReward}|],
   [i|     * finalization reward: #{_cpRewardParameters ^. mdFinalizationReward}|],

--- a/src/Concordium/Client/Output.hs
+++ b/src/Concordium/Client/Output.hs
@@ -1235,7 +1235,8 @@ printBlockInfo b =
        , printf "Baker:                      %s" (showMaybe show $ Queries.biBlockBaker b)
        , printf "Transaction count:          %d" (Queries.biTransactionCount b)
        , printf "Transaction energy cost:    %s" (showNrg $ Queries.biTransactionEnergyCost b)
-       , printf "Transactions size:          %d" (Queries.biTransactionsSize b) ]
+       , printf "Transactions size:          %d" (Queries.biTransactionsSize b)
+       , printf "Protocol version:           %s" (show $ Queries.biProtocolVersion b)]
 
 
 -- ID LAYER

--- a/src/Concordium/Client/Output.hs
+++ b/src/Concordium/Client/Output.hs
@@ -1214,6 +1214,10 @@ showBlockHashInput :: Queries.BlockHashInput -> String
 showBlockHashInput Queries.Best = [i|best block|]
 showBlockHashInput (Queries.Given bh) = [i|block with hash #{bh}|]
 showBlockHashInput Queries.LastFinal = [i|last finalized block|]
+showBlockHashInput (Queries.AtHeight bhi) =
+    case bhi of
+        Queries.Relative{..} -> [i|@#{rBlockHeight}/#{rGenesisIndex}#{if rRestrict then ("!" :: String) else ""} |]
+        Queries.Absolute{..} -> [i|@#{aBlockHeight}|]
 
 printBlockInfo :: Queries.BlockInfo -> Printer
 printBlockInfo b =

--- a/src/Concordium/Client/Runner.hs
+++ b/src/Concordium/Client/Runner.hs
@@ -3773,6 +3773,11 @@ processLegacyCmd action backend =
         readBlockHashOrDefault Best block >>=
           getCryptographicParameters >>=
             printResponseValueAsJSON . fmap (fmap (Versioned $ Version 0))
+    GetNextUpdateSequenceNumbers block ->
+      withClient backend $
+        readBlockHashOrDefault Best block >>=
+          getNextUpdateSequenceNumbers >>=
+            printResponseValueAsJSON
   where
     -- |Print the response value under the provided mapping,
     -- or fail with an error message if the response contained

--- a/test/SimpleClientTests/BlockSpec.hs
+++ b/test/SimpleClientTests/BlockSpec.hs
@@ -27,7 +27,8 @@ blockSpec = describe "block" $ do
     , "Baker:                      53"
     , "Transaction count:          10"
     , "Transaction energy cost:    101 NRG"
-    , "Transactions size:          11" ]
+    , "Transactions size:          11"
+    , "Protocol version:           P1"]
   specify "without baker" $ p exampleBlockInfoWithoutBaker `shouldBe`
     [ "Hash:                       0a5d64f644461d95315a781475b83f723f74d1c21542bd4f3e234d6173374389"
     , "Parent block:               0f71eeca9f0a497dc4427cab0544f2bcb820b328ad97be29181e212edea708fd"
@@ -43,7 +44,8 @@ blockSpec = describe "block" $ do
     , "Baker:                      none"
     , "Transaction count:          10"
     , "Transaction energy cost:    101 NRG"
-    , "Transactions size:          11" ]
+    , "Transactions size:          11"
+    , "Protocol version:           P3"]
   where p = execWriter . printBlockInfo
 
 exampleBlockInfoWithBaker :: BlockInfo
@@ -64,7 +66,8 @@ exampleBlockInfoWithBaker =
   , biTransactionCount = 10
   , biTransactionEnergyCost = 101
   , biTransactionsSize = 11
-  , biBlockStateHash = exampleStateHash }
+  , biBlockStateHash = exampleStateHash
+  , biProtocolVersion = Types.P1}
 
 exampleBlockInfoWithoutBaker :: BlockInfo
 exampleBlockInfoWithoutBaker =
@@ -84,7 +87,8 @@ exampleBlockInfoWithoutBaker =
   , biTransactionCount = 10
   , biTransactionEnergyCost = 101
   , biTransactionsSize = 11
-  , biBlockStateHash = exampleStateHash }
+  , biBlockStateHash = exampleStateHash
+  , biProtocolVersion = Types.P3}
 
 exampleBlockHash1 :: Types.BlockHash
 exampleBlockHash1 = read "0a5d64f644461d95315a781475b83f723f74d1c21542bd4f3e234d6173374389"


### PR DESCRIPTION
## Purpose

Fixes #255 

```json
{
    "addAnonymityRevoker": 1,
    "addIdentityProvider": 2,
    "blockEnergyLimit": 1,
    "cooldownParameters": 1,
    "electionDifficulty": 1,
    "euroPerEnergy": 1,
    "finalizationCommitteeParameters": 1,
    "foundationAccount": 1,
    "gASRewards": 1,
    "level1Keys": 2,
    "level2Keys": 3,
    "microCCDPerEuro": 22938,
    "minBlockTime": 1,
    "mintDistribution": 1,
    "poolParameters": 2,
    "protocol": 5,
    "rootKeys": 1,
    "timeParameters": 1,
    "timeoutParameters": 1,
    "transactionFeeDistribution": 1
}
```

Additionally due to the bump in concordium-base the output of `raw GetBlockInfo` contains a protocol version.

Depends on
- [x] https://github.com/Concordium/concordium-base/pull/389

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [x] (If necessary) I have updated the CHANGELOG.
