### PR TITLE
Support grpc updates

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -8,6 +8,13 @@
 - The client needs node version at least 5.4.
 - Add `raw GetNextUpdateSequenceNumbers` subcommand.
 - Add node version to the output of `raw GetNodeInfo`.
+- Add current timeout duration, current round, current epoch and trigger block time to the output
+  of `raw GetConsensusInfo`.
+- Add current timeout duration, current round, current epoch and trigger block time to the output
+  of `consensus status` when they are present.
+- Add round and epoch to the output of `raw GetBlockInfo`.
+- Add round and epoch to the output of `block show` when they are present.
+- Print "Block time" instead of "Slot time" in the output of `block show`.
 
 ## 5.2.0
 

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -15,6 +15,7 @@
 - Add round and epoch to the output of `raw GetBlockInfo`.
 - Add round and epoch to the output of `block show` when they are present.
 - Print "Block time" instead of "Slot time" in the output of `block show`.
+- In the output of `consensus show-parameters`, only print election difficulty when present. 
 
 ## 5.2.0
 

--- a/src/Concordium/Client/Output.hs
+++ b/src/Concordium/Client/Output.hs
@@ -1240,7 +1240,7 @@ printBlockInfo b =
        , printf "Receive time:               %s" (showTimeFormatted $ Queries.biBlockReceiveTime b)
        , printf "Arrive time:                %s" (showTimeFormatted $ Queries.biBlockArriveTime b)
        ] ++ maybeSlot (Queries.biBlockSlot b) ++ [
-         printf "Slot time:                  %s" (showTimeFormatted $ Queries.biBlockSlotTime b)
+         printf "Block time:                  %s" (showTimeFormatted $ Queries.biBlockSlotTime b)
        , printf "Height:                     %s" (show $ Queries.biBlockHeight b)
        , printf "Height since last genesis:  %s" (show $ Queries.biEraBlockHeight b)
        , printf "Genesis index:              %s" (show $ Queries.biGenesisIndex b)

--- a/src/Concordium/Client/Output.hs
+++ b/src/Concordium/Client/Output.hs
@@ -1002,9 +1002,9 @@ printConsensusStatus r =
     bftStatus Nothing = []
     bftStatus (Just Queries.ConcordiumBFTStatus{..}) = [
          printf "Current timeout duration:    %s" (showDuration $ Time.durationMillis cbftsCurrentTimeoutDuration),
-         printf "Current round:    %s" (show cbftsCurrentRound),
-         printf "Current epoch:    %s" (show cbftsCurrentEpoch),
-         printf "Trigger block time:    %s" (show cbftsTriggerBlockTime)
+         printf "Current round:               %s" (show cbftsCurrentRound),
+         printf "Current epoch:               %s" (show cbftsCurrentEpoch),
+         printf "Trigger block time:          %s" (show cbftsTriggerBlockTime)
       ]
 
 
@@ -1240,7 +1240,7 @@ printBlockInfo b =
        , printf "Receive time:               %s" (showTimeFormatted $ Queries.biBlockReceiveTime b)
        , printf "Arrive time:                %s" (showTimeFormatted $ Queries.biBlockArriveTime b)
        ] ++ maybeSlot (Queries.biBlockSlot b) ++ [
-         printf "Block time:                  %s" (showTimeFormatted $ Queries.biBlockSlotTime b)
+         printf "Block time:                 %s" (showTimeFormatted $ Queries.biBlockSlotTime b)
        , printf "Height:                     %s" (show $ Queries.biBlockHeight b)
        , printf "Height since last genesis:  %s" (show $ Queries.biEraBlockHeight b)
        , printf "Genesis index:              %s" (show $ Queries.biGenesisIndex b)
@@ -1254,9 +1254,9 @@ printBlockInfo b =
     maybeSlot Nothing = []
     maybeSlot (Just s) = [printf "Slot:                       %s" (show s)]
     maybeRound Nothing = []
-    maybeRound (Just r) = [printf "Round:                       %s" (show r)]
+    maybeRound (Just r) = [printf "Round:                      %s" (show r)]
     maybeEpoch Nothing = []
-    maybeEpoch (Just e) = [printf "Epoch:                       %s" (show e)]
+    maybeEpoch (Just e) = [printf "Epoch:                      %s" (show e)]
 
 
 -- ID LAYER

--- a/src/Concordium/Client/Output.hs
+++ b/src/Concordium/Client/Output.hs
@@ -1011,8 +1011,8 @@ printConsensusStatus r =
 -- |Print Birk parameters from a @BlockBirkParameters@.
 printQueryBirkParameters :: Bool -> Queries.BlockBirkParameters -> Map.Map IDTypes.AccountAddress Text -> Printer
 printQueryBirkParameters includeBakers r addrmap = do
-  tell [ printf "Election nonce:      %s" (show $ Queries.bbpElectionNonce r),
-         printf "Election difficulty: %s" (show $ Queries.bbpElectionDifficulty r) ]
+  tell $ printf "Election nonce:      %s" (show $ Queries.bbpElectionNonce r)
+         : maybeElectionDiffiulty (Queries.bbpElectionDifficulty r)
   when includeBakers $
     case Vec.toList $ Queries.bbpBakers r of
       [] ->
@@ -1033,6 +1033,9 @@ printQueryBirkParameters includeBakers r addrmap = do
                                 then " <0.0001 %" :: String
                                 else printf "%8.4f %%" (lp*100)
           accountName bkr = fromMaybe " " $ Map.lookup bkr addrmap
+  where
+    maybeElectionDiffiulty Nothing = []
+    maybeElectionDiffiulty (Just ed) = [printf "Election difficulty: %s" (show ed)]
 
 -- |Print Birk parameters from a @BirkParametersResult@.
 printBirkParameters :: Bool -> BirkParametersResult -> Map.Map IDTypes.AccountAddress Text -> Printer

--- a/test/SimpleClientTests/BlockSpec.hs
+++ b/test/SimpleClientTests/BlockSpec.hs
@@ -20,7 +20,7 @@ blockSpec = describe "block" $ do
     , "Receive time:               Mon, 12 Jan 1970 13:46:40 UTC"
     , "Arrive time:                Thu, 15 Jan 1970 06:56:07 UTC"
     , "Slot:                       1337"
-    , "Slot time:                  Sat, 24 Jan 1970 03:33:20 UTC"
+    , "Block time:                 Sat, 24 Jan 1970 03:33:20 UTC"
     , "Height:                     121"
     , "Height since last genesis:  121"
     , "Genesis index:              0"
@@ -37,7 +37,7 @@ blockSpec = describe "block" $ do
     , "Receive time:               Mon, 12 Jan 1970 13:46:40 UTC"
     , "Arrive time:                Thu, 15 Jan 1970 06:56:07 UTC"
     , "Slot:                       1337"
-    , "Slot time:                  Sat, 24 Jan 1970 03:33:20 UTC"
+    , "Block time:                 Sat, 24 Jan 1970 03:33:20 UTC"
     , "Height:                     121"
     , "Height since last genesis:  121"
     , "Genesis index:              0"
@@ -57,7 +57,7 @@ exampleBlockInfoWithBaker =
   , biFinalized = False
   , biBlockReceiveTime = exampleTime1
   , biBlockArriveTime = exampleTime2
-  , biBlockSlot = 1337
+  , biBlockSlot = Just 1337
   , biBlockHeight = 121
   , biGenesisIndex = 0
   , biEraBlockHeight = 121
@@ -67,7 +67,9 @@ exampleBlockInfoWithBaker =
   , biTransactionEnergyCost = 101
   , biTransactionsSize = 11
   , biBlockStateHash = exampleStateHash
-  , biProtocolVersion = Types.P1}
+  , biProtocolVersion = Types.P1
+  , biRound = Nothing
+  , biEpoch = Nothing}
 
 exampleBlockInfoWithoutBaker :: BlockInfo
 exampleBlockInfoWithoutBaker =
@@ -78,7 +80,7 @@ exampleBlockInfoWithoutBaker =
   , biFinalized = False
   , biBlockReceiveTime = exampleTime1
   , biBlockArriveTime = exampleTime2
-  , biBlockSlot = 1337
+  , biBlockSlot = Just 1337
   , biBlockSlotTime = exampleTime3
   , biBlockHeight = 121
   , biGenesisIndex = 0
@@ -88,7 +90,9 @@ exampleBlockInfoWithoutBaker =
   , biTransactionEnergyCost = 101
   , biTransactionsSize = 11
   , biBlockStateHash = exampleStateHash
-  , biProtocolVersion = Types.P3}
+  , biProtocolVersion = Types.P3
+  , biRound = Nothing
+  , biEpoch = Nothing}
 
 exampleBlockHash1 :: Types.BlockHash
 exampleBlockHash1 = read "0a5d64f644461d95315a781475b83f723f74d1c21542bd4f3e234d6173374389"

--- a/test/SimpleClientTests/ConsensusSpec.hs
+++ b/test/SimpleClientTests/ConsensusSpec.hs
@@ -140,12 +140,13 @@ exampleStatusWithOptionalFields =
   , csFinalizationPeriodEMA = Just 100
   , csFinalizationPeriodEMSD = Just 200
   , csGenesisTime = exampleTime1
-  , csSlotDuration = 100000
+  , csSlotDuration = Just 100000
   , csEpochDuration = 100000
   , csProtocolVersion = P1
   , csGenesisIndex = 0
   , csCurrentEraGenesisBlock = exampleBlockHash2
-  , csCurrentEraGenesisTime = exampleTime1 }
+  , csCurrentEraGenesisTime = exampleTime1
+  , csConcordiumBFTStatus = Nothing }
 
 exampleStatusWithoutOptionalFields :: ConsensusStatus
 exampleStatusWithoutOptionalFields =
@@ -174,12 +175,13 @@ exampleStatusWithoutOptionalFields =
   , csFinalizationPeriodEMA = Nothing
   , csFinalizationPeriodEMSD = Nothing
   , csGenesisTime = exampleTime1
-  , csSlotDuration = 100000
+  , csSlotDuration = Just 100000
   , csEpochDuration = 100000
   , csProtocolVersion = P1
   , csGenesisIndex = 0
   , csCurrentEraGenesisBlock = exampleBlockHash2
-  , csCurrentEraGenesisTime = exampleTime1 }
+  , csCurrentEraGenesisTime = exampleTime1
+  , csConcordiumBFTStatus = Nothing }
 
 exampleBirkParameters :: BirkParametersResult
 exampleBirkParameters =


### PR DESCRIPTION
## Purpose
Closes https://github.com/Concordium/concordium-client/issues/262.

## Changes
* `FromProto` instances have been updated to reflect the changes to `ConsensusStatus`, `BlockInfo` and `BlockBirkParameters`.
* Changes to `printConsensusStatus`:
  - Only print slot duration when present. 
  - Print the newly introduced current timeout duration, current round, current epoch and trigger block time when present.
 * Changes to `printBlockInfo`:
   - Only print slot when present.
   - Print the newly introduced round and epoch when present.
   - Print "Block time" instead of "Slot time".

## Checklist

- [ ] My code follows the style of this project.
- [ ] The code compiles without warnings.
- [ ] I have performed a self-review of the changes.
- [ ] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [ ] (If necessary) I have updated the CHANGELOG.

