### PR TITLE
Denote the minimum block time shown in parameters with ms unit.

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Add an unit (ms) to the minimum block time shown in the chain parameters for P6.
+
 ## 6.0.0
 
 - Remove a stray `CTrue` in output of `consensus show-chain-parameters`.

--- a/src/Concordium/Client/Output.hs
+++ b/src/Concordium/Client/Output.hs
@@ -1194,7 +1194,7 @@ printChainParametersV2 ChainParameters {..} = tell [
   [i|     * base timeout: #{_cpConsensusParameters ^. cpTimeoutParameters ^. tpTimeoutBase} ms.|],
   [i|     * timeout increase: #{showRatio (_cpConsensusParameters ^. cpTimeoutParameters ^. tpTimeoutIncrease)}|],
   [i|     * timeout decrease: #{showRatio (_cpConsensusParameters ^. cpTimeoutParameters ^. tpTimeoutDecrease)}|],
-  [i|  + minimum time between blocks: #{_cpConsensusParameters ^. cpMinBlockTime}|],
+  [i|  + minimum time between blocks: #{_cpConsensusParameters ^. cpMinBlockTime} ms.|],
   [i|  + block energy limit: #{_cpConsensusParameters ^. cpBlockEnergyLimit}|],
   "",
   [i|\# Finalization committee parameters:|],


### PR DESCRIPTION
## Purpose

Clean up the output of p6 parameters such that the minimum block time is denoted with ms.

## Changes

_Describe the changes that were needed.

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [x] (If necessary) I have updated the CHANGELOG.
