### PR TITLE
Stop (early) consuming a stream if an error was returned.

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- End stream consumption early if an error is returned.
+
 ## 6.0.1
 
 - Add an unit (ms) to the minimum block time shown in the chain parameters for P6.

--- a/src/Concordium/Client/Runner/Helper.hs
+++ b/src/Concordium/Client/Runner/Helper.hs
@@ -99,16 +99,18 @@ toGRPCResult' =
                 -- The request failed.
                 Left e -> RequestFailed $ "Unable to send query: " ++ show e
         -- @ServerStreamOutput@ contains a triple consisting of a result,
-        -- headers and trailers. The trailers are unused.
-        ServerStreamOutput (t, hds, _trs) ->
+        -- headers and trailers.
+        ServerStreamOutput (t, hds, trs) -> do
             -- Check whether the stream returned an error before trying to consume it.
-            let hs = map (\(hn, hv) -> (CI.mk hn, hv)) hds
-            in  case readTrailers hs of
-                    Left _ -> StatusInvalid
-                    Right (GRPCStatus code message) ->
-                        if code /= OK
-                            then StatusNotOk (code, "GRPC error: " <> show message)
-                            else StatusOk (GRPCResponse hs t)
+            let ts = map (\(hn, hv) -> (CI.mk hn, hv)) trs
+            case readTrailers ts of
+                Left _ -> StatusInvalid
+                Right (GRPCStatus code message) ->
+                    if code /= OK
+                        then StatusNotOk (code, "GRPC error: " <> show message)
+                        else
+                            let hs = map (\(hn, hv) -> (CI.mk hn, hv)) hds
+                            in  StatusOk (GRPCResponse hs t)
 
 -- |Convert a GRPC helper output to a unified result type.
 toGRPCResult :: Maybe (GRPCOutput t) -> GRPCResult t

--- a/stack.yaml
+++ b/stack.yaml
@@ -45,7 +45,7 @@ extra-deps:
   commit: 4e9058db74e7a27dee0c92c4a754086e8a45a592
 
 - github: Concordium/http2-grpc-haskell
-  commit: a4a0a31d44f754bf61868552ee5b256d94eed4de
+  commit: e52874ac2923f5177696e6dd4251fdb0f7dda87b
   subdirs:
     - http2-client-grpc
     - http2-grpc-proto-lens


### PR DESCRIPTION
## Purpose

Fix a bug where if a stream response returned an error but yielded no elements, then the client would end up hanging.

This PR leverages the fix here https://github.com/Concordium/http2-grpc-haskell/pull/6 by checking whether the output of the stream returned an error before consuming. 

## Changes

- Update the http2-grpc-haskell dependency that makes this bugfix possible. https://github.com/Concordium/http2-grpc-haskell/pull/6
- Check for the header status code is not 'ok' and return an appropriate error if so. 

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [x] (If necessary) I have updated the CHANGELOG.

