### PR TITLE
Baker earliest win time queries

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -2,9 +2,12 @@
 
 ## Unreleased
 
+- Add `baker win-time` command for determining the earliest time a specified baker is expected to
+  bake.
 - End stream consumption early if an error is returned.
 - Add raw support for `GetBakersRewardPeriod`.
 - Add raw support for `GetBlockCertificates`.
+- Add raw support for `GetBakerEarliestWinTime`.
 - Add support for `CommissionRates` in `CurrentPaydayBakerPoolStatus` (Only available for node versions > 6.0).
 
 ## 6.0.1

--- a/src/Concordium/Client/Commands.hs
+++ b/src/Concordium/Client/Commands.hs
@@ -510,6 +510,11 @@ data BakerCmd
         { bodsOpenForDelegation :: !OpenStatus,
           bodsTransactionOpts :: !(TransactionOpts (Maybe Energy))
         }
+    | BakerGetEarliestWinTime
+        { bgewtBakerId :: !BakerId,
+          bgewtShowLocalTime :: !Bool,
+          bgewtPoll :: !Bool
+        }
     deriving (Show)
 
 data DelegatorCmd
@@ -1626,6 +1631,7 @@ bakerCmds =
                         <> bakerUpdateUpdateMetadataURL
                         <> bakerUpdateOpenDelegationStatus
                         <> bakerConfigureCmd
+                        <> bakerGetEarliestWinTime
                     )
             )
             (progDesc "Commands for creating and deploying baker credentials.")
@@ -1765,6 +1771,25 @@ bakerUpdateOpenDelegationStatus =
                 <*> transactionOptsParser
             )
             (progDesc "Change whether to allow other parties to delegate stake to the baker.")
+        )
+
+bakerGetEarliestWinTime :: Mod CommandFields BakerCmd
+bakerGetEarliestWinTime =
+    command
+        "win-time"
+        ( info
+            ( BakerGetEarliestWinTime
+                <$> argument auto (metavar "BAKER-ID" <> help "Baker ID to query.")
+                <*> switch
+                    ( long "local-time"
+                        <> help "Display time in the local time zone (instead of UTC)."
+                    )
+                <*> switch
+                    ( long "poll"
+                        <> help "Repeatedly poll for the latest time."
+                    )
+            )
+            (progDesc "Show the earliest time the baker may be expected to bake a block.")
         )
 
 bakerSetKeysCmd :: Mod CommandFields BakerCmd

--- a/src/Concordium/Client/GRPC2.hs
+++ b/src/Concordium/Client/GRPC2.hs
@@ -3217,6 +3217,12 @@ getNextSequenceNumber accAddress = withUnary (call @"getNextAccountSequenceNumbe
   where
     msg = toProto accAddress
 
+-- |Get the earliest time at which a baker may be expected to bake a block.
+getBakerEarliestWinTime :: (MonadIO m) => BakerId -> ClientMonad m (GRPCResult (FromProtoResult Timestamp))
+getBakerEarliestWinTime bakerId = withUnary (call @"getBakerEarliestWinTime") msg (fmap fromProto)
+  where
+    msg = toProto bakerId
+
 -- |Call a unary V2 GRPC API endpoint and return the result.
 withUnary ::
     ( HasMethod CS.Queries m,

--- a/src/Concordium/Client/LegacyCommands.hs
+++ b/src/Concordium/Client/LegacyCommands.hs
@@ -16,11 +16,11 @@ data LegacyCmd
       GetTransactionStatus
         { legacyTransactionHash :: !Text
         }
-    | -- |Get non finalized transactions for a given account.
+    | -- | Get non finalized transactions for a given account.
       GetAccountNonFinalized
         { legacyAddress :: !Text
         }
-    | -- |Get non finalized transactions for a given account.
+    | -- | Get non finalized transactions for a given account.
       GetNextAccountNonce
         { legacyAddress :: !Text
         }
@@ -96,7 +96,7 @@ data LegacyCmd
       GetModuleList
         { legacyBlockHash :: !(Maybe Text)
         }
-    | -- |Queries the gRPC server for the node information.
+    | -- | Queries the gRPC server for the node information.
       GetNodeInfo
     | GetPeerData
         { -- | Whether to include bootstrapper node in the stats or not.
@@ -140,6 +140,9 @@ data LegacyCmd
         {legacyBlockHash :: !(Maybe Text)}
     | GetNextUpdateSequenceNumbers
         {legacyBlockHash :: !(Maybe Text)}
+    | GetBakerEarliestWinTime
+        { legacyBakerId :: !BakerId
+        }
     deriving (Show)
 
 legacyProgramOptions :: Parser LegacyCmd
@@ -184,6 +187,7 @@ legacyProgramOptions =
             <> getAnonymityRevokersCommand
             <> getCryptographicParametersCommand
             <> getNextUpdateSequenceNumbersCommand
+            <> getBakerEarliestWinTimeCommand
         )
 
 getPeerDataCommand :: Mod CommandFields LegacyCmd
@@ -386,6 +390,20 @@ getNextUpdateSequenceNumbersCommand =
                 <$> optional (strArgument (metavar "BLOCK-HASH" <> help "Hash of the block to query (default: Query the best block)"))
             )
             (progDesc "Query the gRPC server for the next update sequence numbers for all update queues.")
+        )
+
+getBakerEarliestWinTimeCommand :: Mod CommandFields LegacyCmd
+getBakerEarliestWinTimeCommand =
+    command
+        "GetBakerEarliestWinTime"
+        ( info
+            ( GetBakerEarliestWinTime
+                <$> argument auto (metavar "BAKER-ID" <> help "Baker ID of the baker.")
+            )
+            ( progDesc
+                "Query the gRPC server for the earliest time that a given baker is expected \
+                \to bake."
+            )
         )
 
 getInstanceInfoCommand :: Mod CommandFields LegacyCmd

--- a/src/Concordium/Client/Runner.hs
+++ b/src/Concordium/Client/Runner.hs
@@ -4081,6 +4081,8 @@ processLegacyCmd action backend =
                 readBlockHashOrDefault Best block
                     >>= getNextUpdateSequenceNumbers
                     >>= printResponseValueAsJSON
+        GetBakerEarliestWinTime bakerId ->
+            withClient backend $ getBakerEarliestWinTime bakerId >>= printResponseValueAsJSON
   where
     -- \|Print the response value under the provided mapping,
     -- or fail with an error message if the response contained

--- a/src/Concordium/Client/Runner.hs
+++ b/src/Concordium/Client/Runner.hs
@@ -3701,11 +3701,12 @@ processBakerCmd action baseCfgDir verbose backend =
             polling :: Int -> Int -> Types.Timestamp -> IO ()
             polling oldLen lastPoll winTimestamp = do
                 newLen <- displayTime oldLen winTimestamp
+                -- Delay for 1 second
                 threadDelay 1_000_000
                 now <- Time.utcTimeToTimestamp <$> getCurrentTime
                 -- We repeat the query every 10th iteration, or every iteration if the timestamp
                 -- is less than 10 seconds in the future.
-                if lastPoll >= 10 || winTimestamp - now < 10_000
+                if lastPoll >= 10 || winTimestamp < now + 10_000
                     then polling newLen 0 =<< getWinTimestamp
                     else polling newLen (lastPoll + 1) winTimestamp
 


### PR DESCRIPTION
## Purpose

This adds support for getting the earliest projected win time for a baker.

## Changes

- Add `raw GetBakerEarliestWinTime` which gets the raw timestamp for a baker by the baker ID.
- Add `baker win-time` which displays the earliest win time for a baker, with options for displaying in the local timezone (as opposed to UTC) and for polling in a loop.

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [x] (If necessary) I have updated the CHANGELOG.
