### PR TITLE
Support for GetWinningBakersEpoch and GetFirstBlockEpoch.

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -5,9 +5,12 @@
 - Add `baker win-time` command for determining the earliest time a specified baker is expected to
   bake.
 - End stream consumption early if an error is returned.
-- Add raw support for `GetBakersRewardPeriod`.
-- Add raw support for `GetBlockCertificates`.
-- Add raw support for `GetBakerEarliestWinTime`.
+- Add support for the following node version 6.1 queries under the `raw` command:
+  - `GetBakersRewardPeriod`
+  - `GetBlockCertificates`
+  - `GetBakerEarliestWinTime`
+  - `GetWinningBakersEpoch`
+  - `GetFirstBlockEpoch`
 - Add support for `CommissionRates` in `CurrentPaydayBakerPoolStatus` (Only available for node versions > 6.0).
 
 ## 6.0.1

--- a/src/Concordium/Client/Commands.hs
+++ b/src/Concordium/Client/Commands.hs
@@ -28,6 +28,7 @@ module Concordium.Client.Commands (
     ParameterFileInput (..),
     InvokerInput (..),
     ExtraBakerAddData (..),
+    EpochSpecifier (..),
 ) where
 
 import Concordium.Client.LegacyCommands

--- a/src/Concordium/Client/LegacyCommands.hs
+++ b/src/Concordium/Client/LegacyCommands.hs
@@ -731,5 +731,5 @@ getFirstBlockEpochCommand =
         "GetFirstBlockEpoch"
         ( info
             (GetFirstBlockEpoch <$> parseEpochSpecifier)
-            (progDesc "Query the first block of an epoch.")
+            (progDesc "Query the first finalized block of an epoch. (Default: the epoch of the last finalized block.)")
         )

--- a/src/Concordium/Client/Runner.hs
+++ b/src/Concordium/Client/Runner.hs
@@ -1657,7 +1657,7 @@ parseEpochRequest
     (EpochSpecifier Nothing Nothing Nothing) =
         return emptyCase
 parseEpochRequest _ _ =
-    logFatal [[i|Invalid arguments: either a genesis index and epoch number should be supplied, or a block hash.|]]
+    logFatal [[i|Invalid arguments: either a genesis index and an epoch number should be supplied, or a block hash.|]]
 
 -- |Process an 'account ...' command.
 processAccountCmd :: AccountCmd -> Maybe FilePath -> Verbose -> Backend -> IO ()

--- a/src/Concordium/Client/Runner.hs
+++ b/src/Concordium/Client/Runner.hs
@@ -1632,6 +1632,33 @@ readBlockHashOrDefault :: (MonadIO m) => BlockHashInput -> Maybe Text -> m Block
 readBlockHashOrDefault d Nothing = return d
 readBlockHashOrDefault _ (Just s) = readOrFail s >>= return . Given
 
+-- |Parse an 'Queries.EpochRequest' from an 'EpochSpecifier'.
+parseEpochRequest ::
+    (MonadIO m) =>
+    -- |Optional value to use if no arguments are specified.
+    Maybe Queries.EpochRequest ->
+    -- |Input specifying the epoch
+    EpochSpecifier ->
+    m Queries.EpochRequest
+parseEpochRequest
+    _
+    EpochSpecifier
+        { esGenesisIndex = Just genIndex,
+          esEpoch = Just epoch,
+          esBlock = Nothing
+        } =
+        return Queries.SpecifiedEpoch{erGenesisIndex = genIndex, erEpoch = epoch}
+parseEpochRequest
+    _
+    EpochSpecifier{esGenesisIndex = Nothing, esEpoch = Nothing, esBlock = Just blk} =
+        return $! Queries.EpochOfBlock (Queries.Given blk)
+parseEpochRequest
+    (Just emptyCase)
+    (EpochSpecifier Nothing Nothing Nothing) =
+        return emptyCase
+parseEpochRequest _ _ =
+    logFatal [[i|Invalid arguments: either a genesis index and epoch number should be supplied, or a block hash.|]]
+
 -- |Process an 'account ...' command.
 processAccountCmd :: AccountCmd -> Maybe FilePath -> Verbose -> Backend -> IO ()
 processAccountCmd action baseCfgDir verbose backend =
@@ -4132,6 +4159,16 @@ processLegacyCmd action backend =
                     >>= printResponseValueAsJSON
         GetBakerEarliestWinTime bakerId ->
             withClient backend $ getBakerEarliestWinTime bakerId >>= printResponseValueAsJSON
+        GetWinningBakersEpoch epochSpec ->
+            withClient backend $
+                parseEpochRequest Nothing epochSpec
+                    >>= getWinningBakersEpoch
+                    >>= printResponseValueAsJSON
+        GetFirstBlockEpoch epochSpec ->
+            withClient backend $
+                parseEpochRequest (Just (Queries.EpochOfBlock Queries.LastFinal)) epochSpec
+                    >>= getFirstBlockEpoch
+                    >>= printResponseValueAsJSON
   where
     -- \|Print the response value under the provided mapping,
     -- or fail with an error message if the response contained


### PR DESCRIPTION
## Purpose

Add raw command support for GetWinningBakersEpoch and GetFirstBlockEpoch.

## Changes

- Parsing for `EpochSpecifier` common to both queries, which allows specifying the epoch by block hash, or by genesis index and epoch number.
- Raw support for `GetWinningBakersEpoch`.
- Raw support for `GetFirstBlockEpoch`.

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [x] (If necessary) I have updated the CHANGELOG.
