### PR TITLE
Show the format flag when importing an account

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -11,8 +11,8 @@
   - `GetBakerEarliestWinTime`
   - `GetWinningBakersEpoch`
   - `GetFirstBlockEpoch`
-  - Add support for `CommissionRates` in `CurrentPaydayBakerPoolStatus` (Only    available for node versions > 6.0).
-  - By default show all options for importing an account.
+  - Add support for `CommissionRates` in `CurrentPaydayBakerPoolStatus` (Only available for node versions > 6.0).
+  - Show all options for importing an account.
 
 
 ## 6.0.1

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -11,7 +11,9 @@
   - `GetBakerEarliestWinTime`
   - `GetWinningBakersEpoch`
   - `GetFirstBlockEpoch`
-- Add support for `CommissionRates` in `CurrentPaydayBakerPoolStatus` (Only available for node versions > 6.0).
+  - Add support for `CommissionRates` in `CurrentPaydayBakerPoolStatus` (Only    available for node versions > 6.0).
+  - By default show all options for importing an account.
+
 
 ## 6.0.1
 

--- a/app/Main.hs
+++ b/app/Main.hs
@@ -2,9 +2,7 @@ module Main where
 
 import Concordium.Client.Commands
 import Concordium.Client.Runner
-import Data.Maybe
 import Options.Applicative
-import System.Environment
 import System.IO
 
 ccPrefs :: ParserPrefs
@@ -29,5 +27,4 @@ setReplacement h = do
 main :: IO ()
 main = do
     mapM_ setReplacement [stdout, stderr]
-    showAllOpts <- lookupEnv "SHOW_ALL_OPTS"
-    process =<< customExecParser ccPrefs (optsParser $ isJust showAllOpts)
+    process =<< customExecParser ccPrefs optsParser


### PR DESCRIPTION
## Purpose

Address https://github.com/Concordium/concordium-client/issues/253

By default show the `format` option when importing an account. 

This change will make it easier to import accounts generated as part of genesis creation. 
Normally this flag is not used by users since they get their account by going through an idp via one of the wallets.

However there will soon be a tool available for running a local chain with a custom genesis. 
In this scenario it's desirable to make it easy for users to import their generated accounts into the client so the client 
is easy to use with their new custom chain.

Note also that the default value `mobile` is the same as before, so the user does not have to explicitly provide this flag if importing a mobile backup.

## Changes

Remove the `SHOW_ALL_OPTS` env variable and by default show all possible options at all times.

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [x] (If necessary) I have updated the CHANGELOG.

