### PR TITLE
Fix linux static build.

### DIFF
--- a/scripts/distributables/linux-build-distributable-concordium-client.sh
+++ b/scripts/distributables/linux-build-distributable-concordium-client.sh
@@ -4,7 +4,9 @@ set -ex
 
 cd /build
 
+# Workaround for stack not setting flags for local dependencies properly.
 sed -i "s/default: False/default: True/g" deps/concordium-base/package.yaml
+sed -i "s/default: False/default: True/g" deps/concordium-base/concordium-base.cabal
 
 stack build --stack-yaml stack.linux-static.yaml
 

--- a/stack.linux-static.yaml
+++ b/stack.linux-static.yaml
@@ -9,7 +9,7 @@ extra-deps:
   commit: 4e9058db74e7a27dee0c92c4a754086e8a45a592
 
 - github: Concordium/http2-grpc-haskell
-  commit: a4a0a31d44f754bf61868552ee5b256d94eed4de
+  commit: e52874ac2923f5177696e6dd4251fdb0f7dda87b
   subdirs:
     - http2-client-grpc
     - http2-grpc-proto-lens


### PR DESCRIPTION
## Purpose


- Fix grpc2-client dependency version
- Set the static flag in concordium-base dependency when building on linux.

## Checklist

- [ ] My code follows the style of this project.
- [ ] The code compiles without warnings.
- [ ] I have performed a self-review of the changes.
- [ ] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [ ] (If necessary) I have updated the CHANGELOG.
