### PR TITLE
Reconnect better

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+- Revise client's reconnect handling so that the client will no longer attempt
+  to automatically reconnect on timeouts and node resource exhaustion.
+
 ## 6.1.0
 
 - Add `baker win-time` command for determining the earliest time a specified baker is expected to

--- a/concordium-client.cabal
+++ b/concordium-client.cabal
@@ -1,11 +1,11 @@
 cabal-version: 1.24
 
--- This file has been generated from package.yaml by hpack version 0.35.1.
+-- This file has been generated from package.yaml by hpack version 0.35.2.
 --
 -- see: https://github.com/sol/hpack
 
 name:           concordium-client
-version:        6.1.0
+version:        6.1.1
 description:    Please see the README on GitHub at <https://github.com/Concordium/concordium-client#readme>
 homepage:       https://github.com/Concordium/concordium-client#readme
 bug-reports:    https://github.com/Concordium/concordium-client/issues

--- a/package.yaml
+++ b/package.yaml
@@ -1,5 +1,5 @@
 name:                concordium-client
-version:             6.1.0
+version:             6.1.1
 github:              "Concordium/concordium-client"
 author:              "Concordium"
 maintainer:          "developers@concordium.com"

--- a/src/Concordium/Client/GRPC2.hs
+++ b/src/Concordium/Client/GRPC2.hs
@@ -41,7 +41,7 @@ import qualified Data.Vector as Vec
 import Data.Word
 import Lens.Micro.Platform
 import Network.GRPC.Client
-import Network.GRPC.HTTP2.Types (GRPCStatusCode (RESOURCE_EXHAUSTED))
+import Network.GRPC.HTTP2.Types (GRPCStatusCode (CANCELLED))
 import Network.GRPC.Client.Helpers hiding (Address)
 import Network.GRPC.HTTP2.ProtoLens
 import Network.HTTP2.Client (ClientError, ClientIO, ExceptT, HostName, PortNumber, TooMuchConcurrency, runExceptT)
@@ -3538,7 +3538,7 @@ withGRPCCore helper k = do
                     return $ k response
                 else return $ k (RequestFailed "Cannot establish connection to GRPC endpoint.")
         (_, Left False) -> do
-          return (k (StatusNotOk (RESOURCE_EXHAUSTED, "Unable to complete query.")))
+          return (k (StatusNotOk (CANCELLED, "Unable to complete query.")))
         (_, Right v) -> 
             let response = toGRPCResult' v
             in  do

--- a/src/Concordium/Client/GRPC2.hs
+++ b/src/Concordium/Client/GRPC2.hs
@@ -41,9 +41,9 @@ import qualified Data.Vector as Vec
 import Data.Word
 import Lens.Micro.Platform
 import Network.GRPC.Client
-import Network.GRPC.HTTP2.Types (GRPCStatusCode (RESOURCE_EXHAUSTED, DEADLINE_EXCEEDED))
 import Network.GRPC.Client.Helpers hiding (Address)
 import Network.GRPC.HTTP2.ProtoLens
+import Network.GRPC.HTTP2.Types (GRPCStatusCode (DEADLINE_EXCEEDED, RESOURCE_EXHAUSTED))
 import Network.HTTP2.Client (ClientError, ClientIO, ExceptT, HostName, PortNumber, TooMuchConcurrency, runExceptT)
 import qualified Web.Cookie as Cookie
 
@@ -3538,8 +3538,8 @@ withGRPCCore helper k = do
                     return $ k response
                 else return $ k (RequestFailed "Cannot establish connection to GRPC endpoint.")
         (_, Left (DoNotRetry r)) -> do
-          return (k r)
-        (_, Right v) -> 
+            return (k r)
+        (_, Right v) ->
             let response = toGRPCResult' v
             in  do
                     addHeaders response

--- a/src/Concordium/Client/Runner/Helper.hs
+++ b/src/Concordium/Client/Runner/Helper.hs
@@ -118,9 +118,12 @@ toGRPCResult' =
                             let hs = map (\(hn, hv) -> (CI.mk hn, hv)) hds
                             in  StatusOk (GRPCResponse hs t)
 
+-- |A helper type to indicate whether a failed RPC call should be retried or
+-- not. This is used internally by the @withUnary@ method.
 data Retry a
     = Retry
-    | DoNotRetry (GRPCResult a)
+    | -- | A call failed with the given 'GRPCResult', and will not be retried.
+      DoNotRetry (GRPCResult a)
 
 -- | Convert a GRPC helper output to a unified result type.
 toGRPCResult :: Either (Retry t) (GRPCOutput t) -> GRPCResult t

--- a/src/Concordium/Client/Runner/Helper.hs
+++ b/src/Concordium/Client/Runner/Helper.hs
@@ -118,11 +118,11 @@ toGRPCResult' =
                             in  StatusOk (GRPCResponse hs t)
 
 -- | Convert a GRPC helper output to a unified result type.
-toGRPCResult :: Maybe (GRPCOutput t) -> GRPCResult t
+toGRPCResult :: Either Bool (GRPCOutput t) -> GRPCResult t
 toGRPCResult ret =
     case ret of
-        Nothing -> RequestFailed "Cannot connect to GRPC server."
-        Just v -> toGRPCResult' v
+        Left _ -> RequestFailed "Cannot connect to GRPC server."
+        Right v -> toGRPCResult' v
 
 printJSON :: (MonadIO m) => Either String Value -> m ()
 printJSON v =

--- a/src/Concordium/Client/Runner/Helper.hs
+++ b/src/Concordium/Client/Runner/Helper.hs
@@ -15,6 +15,7 @@ module Concordium.Client.Runner.Helper (
     GRPCOutput (..),
     GRPCResponse (..),
     GRPCHeaderList,
+    Retry (..)
 ) where
 
 import Concordium.Client.Cli (logFatal)
@@ -117,11 +118,16 @@ toGRPCResult' =
                             let hs = map (\(hn, hv) -> (CI.mk hn, hv)) hds
                             in  StatusOk (GRPCResponse hs t)
 
+data Retry a =
+  Retry
+  | DoNotRetry (GRPCResult a)
+
 -- | Convert a GRPC helper output to a unified result type.
-toGRPCResult :: Either Bool (GRPCOutput t) -> GRPCResult t
+toGRPCResult :: Either (Retry t) (GRPCOutput t) -> GRPCResult t
 toGRPCResult ret =
     case ret of
-        Left _ -> RequestFailed "Cannot connect to GRPC server."
+        Left Retry -> RequestFailed "Cannot connect to GRPC server."
+        Left (DoNotRetry r) -> r
         Right v -> toGRPCResult' v
 
 printJSON :: (MonadIO m) => Either String Value -> m ()

--- a/src/Concordium/Client/Runner/Helper.hs
+++ b/src/Concordium/Client/Runner/Helper.hs
@@ -118,8 +118,8 @@ toGRPCResult' =
                             let hs = map (\(hn, hv) -> (CI.mk hn, hv)) hds
                             in  StatusOk (GRPCResponse hs t)
 
--- |A helper type to indicate whether a failed RPC call should be retried or
--- not. This is used internally by the @withUnary@ method.
+-- | A helper type to indicate whether a failed RPC call should be retried or
+--  not. This is used internally by the @withUnary@ method.
 data Retry a
     = Retry
     | -- | A call failed with the given 'GRPCResult', and will not be retried.

--- a/src/Concordium/Client/Runner/Helper.hs
+++ b/src/Concordium/Client/Runner/Helper.hs
@@ -15,7 +15,7 @@ module Concordium.Client.Runner.Helper (
     GRPCOutput (..),
     GRPCResponse (..),
     GRPCHeaderList,
-    Retry (..)
+    Retry (..),
 ) where
 
 import Concordium.Client.Cli (logFatal)
@@ -118,9 +118,9 @@ toGRPCResult' =
                             let hs = map (\(hn, hv) -> (CI.mk hn, hv)) hds
                             in  StatusOk (GRPCResponse hs t)
 
-data Retry a =
-  Retry
-  | DoNotRetry (GRPCResult a)
+data Retry a
+    = Retry
+    | DoNotRetry (GRPCResult a)
 
 -- | Convert a GRPC helper output to a unified result type.
 toGRPCResult :: Either (Retry t) (GRPCOutput t) -> GRPCResult t


### PR DESCRIPTION
## Purpose

If a request fails due to timeout or resource exhaustion do not drop the connection and reconnect.

This helps in cases of high load which previously led to a lot of reconnects.

## Checklist

- [ ] My code follows the style of this project.
- [ ] The code compiles without warnings.
- [ ] I have performed a self-review of the changes.
- [ ] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [ ] (If necessary) I have updated the CHANGELOG.
