### PR TITLE
Update Haskell to LTS 22.9

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -34,7 +34,7 @@ on:
 
 env:
   RUST: 1.68
-  GHC: 9.2.7
+  GHC: 9.6.4
 
 jobs:
   fourmolu:

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+## 6.3.0
+
 - Update GHC version to 9.6.4 (lts-22.9).
 
 ## 6.2.1

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Update GHC version to 9.6.4 (lts-22.9).
+
 ## 6.2.1
 
 - Remove uses of `baker` term when printing chain parameters.

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -2,8 +2,6 @@
 
 ## Unreleased
 
-## 6.3.0
-
 - Update GHC version to 9.6.4 (lts-22.9).
 
 ## 6.2.1

--- a/concordium-client.cabal
+++ b/concordium-client.cabal
@@ -68,12 +68,12 @@ library
       FlexibleContexts
       LambdaCase
       TupleSections
+      TypeOperators
   ghc-options: -Wall -Wcompat -Werror=missing-fields -Wredundant-constraints -O
   build-depends:
       aeson
     , aeson-pretty
     , ansi-terminal
-    , ansi-wl-pprint
     , async >=2.2
     , attoparsec
     , base >=4.7 && <5
@@ -99,8 +99,9 @@ library
     , mtl
     , optparse-applicative
     , pretty
+    , prettyprinter
+    , prettyprinter-ansi-terminal
     , proto-lens ==0.7.*
-    , proto-lens-protobuf-types ==0.7.*
     , random
     , scientific
     , split
@@ -127,6 +128,7 @@ executable concordium-client
       FlexibleContexts
       LambdaCase
       TupleSections
+      TypeOperators
   ghc-options: -Wall -Wcompat -Werror=missing-fields -Wredundant-constraints -O
   build-depends:
       base
@@ -150,6 +152,7 @@ executable tx-generator
       FlexibleContexts
       LambdaCase
       TupleSections
+      TypeOperators
   ghc-options: -Wall -Wcompat -Werror=missing-fields -Wredundant-constraints -O
   build-depends:
       aeson
@@ -195,6 +198,7 @@ test-suite concordium-client-test
       FlexibleContexts
       LambdaCase
       TupleSections
+      TypeOperators
   ghc-options: -Wall -Wcompat -Werror=missing-fields -Wredundant-constraints -O
   build-depends:
       HUnit >=1.6

--- a/concordium-client.cabal
+++ b/concordium-client.cabal
@@ -5,7 +5,7 @@ cabal-version: 1.24
 -- see: https://github.com/sol/hpack
 
 name:           concordium-client
-version:        6.2.1
+version:        6.3.0
 description:    Please see the README on GitHub at <https://github.com/Concordium/concordium-client#readme>
 homepage:       https://github.com/Concordium/concordium-client#readme
 bug-reports:    https://github.com/Concordium/concordium-client/issues

--- a/concordium-client.cabal
+++ b/concordium-client.cabal
@@ -75,10 +75,8 @@ library
     , aeson-pretty
     , ansi-terminal
     , async >=2.2
-    , attoparsec
     , base >=4.7 && <5
     , base16-bytestring
-    , base64-bytestring
     , bytestring
     , case-insensitive
     , cborg
@@ -87,7 +85,6 @@ library
     , concordium-base
     , containers
     , cookie
-    , cryptonite
     , directory
     , filepath
     , hashable >=1.2
@@ -102,14 +99,12 @@ library
     , prettyprinter
     , prettyprinter-ansi-terminal
     , proto-lens ==0.7.*
-    , random
     , scientific
     , split
     , string-interpolate
     , text
     , time
     , transformers
-    , unordered-containers
     , uri-encode >=1.5
     , vector >=0.12
   default-language: Haskell2010
@@ -157,10 +152,8 @@ executable tx-generator
   build-depends:
       aeson
     , base
-    , bytestring
     , concordium-base
     , concordium-client
-    , containers
     , mtl
     , optparse-applicative
     , time
@@ -211,14 +204,10 @@ test-suite concordium-client-test
     , concordium-base
     , concordium-client
     , containers
-    , filepath
     , hspec >=2.6
-    , hspec-expectations >=0.8
     , mtl >=2.2.2
     , random
     , text
     , time
-    , transformers
-    , unordered-containers
     , vector
   default-language: Haskell2010

--- a/generator/Main.hs
+++ b/generator/Main.hs
@@ -17,6 +17,7 @@ import Concordium.Types.Queries
 import Concordium.Types.Transactions
 
 import Control.Concurrent
+import Control.Monad
 import Control.Monad.Reader
 import qualified Data.Aeson as AE
 import qualified Data.Aeson.Types as AE

--- a/package.yaml
+++ b/package.yaml
@@ -24,6 +24,7 @@ default-extensions:
 - FlexibleContexts
 - LambdaCase
 - TupleSections
+- TypeOperators
 
 ghc-options: -Wall
 
@@ -57,7 +58,6 @@ library:
     - aeson
     - aeson-pretty
     - ansi-terminal
-    - ansi-wl-pprint
     - attoparsec
     - base >=4.7 && <5
     - base16-bytestring
@@ -85,8 +85,9 @@ library:
     - unordered-containers
     - hashable >= 1.2
     - pretty
+    - prettyprinter
+    - prettyprinter-ansi-terminal
     - proto-lens == 0.7.*
-    - proto-lens-protobuf-types == 0.7.*
     - microlens-platform
     - transformers
     - uri-encode >= 1.5

--- a/package.yaml
+++ b/package.yaml
@@ -1,5 +1,5 @@
 name:                concordium-client
-version:             6.3.0
+version:             6.2.1
 github:              "Concordium/concordium-client"
 author:              "Concordium"
 maintainer:          "developers@concordium.com"

--- a/package.yaml
+++ b/package.yaml
@@ -1,5 +1,5 @@
 name:                concordium-client
-version:             6.2.1
+version:             6.3.0
 github:              "Concordium/concordium-client"
 author:              "Concordium"
 maintainer:          "developers@concordium.com"

--- a/package.yaml
+++ b/package.yaml
@@ -58,10 +58,8 @@ library:
     - aeson
     - aeson-pretty
     - ansi-terminal
-    - attoparsec
     - base >=4.7 && <5
     - base16-bytestring
-    - base64-bytestring
     - bytestring
     - case-insensitive
     - cereal
@@ -69,11 +67,9 @@ library:
     - cborg-json
     - concordium-base
     - containers
-    - cryptonite
     - directory
     - filepath
     - optparse-applicative
-    - random
     - split
     - mtl
     - text
@@ -82,7 +78,6 @@ library:
     - http2-client >= 0.9
     - http2-grpc-types
     - http2-grpc-proto-lens
-    - unordered-containers
     - hashable >= 1.2
     - pretty
     - prettyprinter
@@ -136,11 +131,9 @@ executables:
     dependencies:
       - optparse-applicative
       - mtl
-      - containers
       - base
       - concordium-client
       - concordium-base
-      - bytestring
       - aeson
       - time
 
@@ -162,14 +155,10 @@ tests:
       - base64-bytestring
       - containers
       - hspec >= 2.6
-      - hspec-expectations >= 0.8
       - HUnit >= 1.6
       - QuickCheck >= 2.13
       - mtl >= 2.2.2
       - text
-      - transformers
       - time
-      - unordered-containers
-      - filepath
       - vector
       - random

--- a/scripts/distributables/linux-concordium-client.Jenkinsfile
+++ b/scripts/distributables/linux-concordium-client.Jenkinsfile
@@ -1,7 +1,7 @@
 pipeline {
     agent any
     environment {
-        GHC_VERSION = '9.2.7'
+        GHC_VERSION = '9.6.4'
         VERSION = sh(
             returnStdout: true, 
             script: '''\

--- a/scripts/distributables/linux-distributable-concordium-client.Dockerfile
+++ b/scripts/distributables/linux-distributable-concordium-client.Dockerfile
@@ -5,7 +5,7 @@ ENV PATH="${PATH}:/root/.cargo/bin:/root/.stack/bin"
 
 COPY . /build
 
-RUN apk add perl g++ make protoc ncurses ncurses-dev zlib zlib-static zlib-dev git wget postgresql-dev gmp-dev gmp
+RUN apk add perl g++ make protoc ncurses ncurses-dev zlib zlib-static zlib-dev git wget postgresql-dev gmp-dev gmp xz
 
 ARG RUST_VERSION=1.68
 RUN wget -qO - https://sh.rustup.rs | sh -s -- --profile minimal --default-toolchain ${RUST_VERSION} -y

--- a/scripts/distributables/linux-distributable-concordium-client.Dockerfile
+++ b/scripts/distributables/linux-distributable-concordium-client.Dockerfile
@@ -1,5 +1,8 @@
 # syntax=docker/dockerfile:experimental
-FROM alpine
+
+# It seems that linker errors occur on alpine:3.19, which seem to be related to
+# (rust) libc and musl, though it is not clear exactly why.
+FROM alpine:3.18
 
 ENV PATH="${PATH}:/root/.cargo/bin:/root/.stack/bin"
 

--- a/scripts/distributables/linux-distributable-concordium-client.Dockerfile
+++ b/scripts/distributables/linux-distributable-concordium-client.Dockerfile
@@ -10,7 +10,7 @@ RUN apk add perl g++ make protoc ncurses ncurses-dev zlib zlib-static zlib-dev g
 ARG RUST_VERSION=1.68
 RUN wget -qO - https://sh.rustup.rs | sh -s -- --profile minimal --default-toolchain ${RUST_VERSION} -y
 
-ARG GHC_VERSION=9.2.7
+ARG GHC_VERSION=9.6.4
 RUN wget -q https://s3-eu-west-1.amazonaws.com/static-libraries.concordium.com/ghc-${GHC_VERSION}-x86_64-unknown-linux-integer-gmp.tar.xz && \
         tar -xf ghc-${GHC_VERSION}-x86_64-unknown-linux-integer-gmp.tar.xz && \
         cd ghc-${GHC_VERSION}-x86_64-unknown-linux && \
@@ -19,7 +19,7 @@ RUN wget -q https://s3-eu-west-1.amazonaws.com/static-libraries.concordium.com/g
         cd .. && \
         rm -rf ghc-${GHC_VERSION}-x86_64-unknown-linux-integer-gmp.tar.xz ghc-${GHC_VERSION}-x86_64-unknown-linux
 
-ARG STACK_VERSION=2.9.1
+ARG STACK_VERSION=2.13.1
 RUN wget -q https://github.com/commercialhaskell/stack/releases/download/v${STACK_VERSION}/stack-${STACK_VERSION}-linux-x86_64.tar.gz && \
         tar -xf stack-${STACK_VERSION}-linux-x86_64.tar.gz && \
         mkdir -p $HOME/.stack/bin && \

--- a/scripts/distributables/macos-concordium-client.Jenkinsfile
+++ b/scripts/distributables/macos-concordium-client.Jenkinsfile
@@ -1,7 +1,7 @@
 pipeline {
     agent { label 'jenkins-worker' }
     environment {
-        GHC_VERSION = '9.2.7'
+        GHC_VERSION = '9.6.4'
         RUST_VERSION = '1.68'
         VERSION = sh(
             returnStdout: true,

--- a/scripts/distributables/windows-concordium-client.Jenkinsfile
+++ b/scripts/distributables/windows-concordium-client.Jenkinsfile
@@ -4,7 +4,7 @@ pipeline {
     stages {
         stage('build') {
             environment {
-                GHC_VERSION = '9.2.7'
+                GHC_VERSION = '9.6.4'
                 BASE_OUTFILE = 's3://distribution.concordium.software/tools/windows/concordium-client'
             }
             steps {

--- a/src/Concordium/Client/Cli.hs
+++ b/src/Concordium/Client/Cli.hs
@@ -17,6 +17,7 @@ import Concordium.Client.Types.TransactionStatus
 import Control.Exception
 import Control.Monad
 import Control.Monad.Except
+import Control.Monad.IO.Class
 import Data.Aeson as AE
 import Data.Aeson.Types (Pair)
 import qualified Data.Char as C

--- a/src/Concordium/Client/Commands.hs
+++ b/src/Concordium/Client/Commands.hs
@@ -40,6 +40,7 @@ import Concordium.Types
 import Concordium.Types.Execution
 import qualified Concordium.Wasm as Wasm
 import Control.Monad
+import Data.String
 import Data.Text hiding (map, unlines)
 import Data.Time.Format.ISO8601
 import Data.Version (showVersion)
@@ -48,7 +49,8 @@ import Network.HTTP2.Client
 import Options.Applicative
 import Options.Applicative.Help.Pretty (fillCat, hang, softline)
 import Paths_concordium_client (version)
-import qualified Text.PrettyPrint.ANSI.Leijen as P
+import qualified Prettyprinter as P
+import qualified Prettyprinter.Render.Terminal as P
 import Text.Printf
 
 type Verbose = Bool
@@ -1967,8 +1969,8 @@ identityShowARsCmd =
             (progDesc "Show anonymity revokers at a given block.")
         )
 
-docFromLines :: [String] -> Maybe P.Doc
-docFromLines = Just . P.vsep . map P.text
+docFromLines :: [String] -> Maybe (P.Doc P.AnsiStyle)
+docFromLines = Just . P.vsep . map fromString
 
 -- | A parameter file used for initializing, updating, and invoking smart contracts.
 --   For the JSON parameter a schema must be embedded in the module or supplied with the --schema flag.

--- a/src/Concordium/Client/Config.hs
+++ b/src/Concordium/Client/Config.hs
@@ -15,7 +15,9 @@ import qualified Concordium.ID.Types as IDTypes
 import Concordium.Types as Types
 
 import Control.Exception
+import Control.Monad
 import Control.Monad.Except
+import Control.Monad.IO.Class
 import Control.Monad.Trans.Except
 import qualified Data.Aeson as AE
 import qualified Data.Aeson.Encode.Pretty as AE

--- a/src/Concordium/Client/Export.hs
+++ b/src/Concordium/Client/Export.hs
@@ -15,7 +15,9 @@ import Concordium.Crypto.SignatureScheme (KeyPair)
 import qualified Concordium.ID.Types as IDTypes
 
 import Control.Exception
+import Control.Monad
 import Control.Monad.Except
+import Control.Monad.IO.Class
 import Data.Aeson ((.:), (.:?), (.=))
 import qualified Data.Aeson as AE
 import qualified Data.Aeson.Types as AE

--- a/src/Concordium/Client/GRPC2.hs
+++ b/src/Concordium/Client/GRPC2.hs
@@ -17,6 +17,7 @@ module Concordium.Client.GRPC2 where
 import Control.Concurrent
 import Control.Concurrent.Async
 import Control.Exception
+import Control.Monad
 import Control.Monad.Reader
 import Control.Monad.State.Strict
 import Data.ByteString (ByteString)
@@ -811,6 +812,7 @@ instance FromProto Proto.ProtocolVersion where
         Proto.PROTOCOL_VERSION_4 -> return P4
         Proto.PROTOCOL_VERSION_5 -> return P5
         Proto.PROTOCOL_VERSION_6 -> return P6
+        Proto.PROTOCOL_VERSION_7 -> return P7
         Proto.ProtocolVersion'Unrecognized _ ->
             fromProtoFail "Unable to convert 'ProtocolVersion'."
 

--- a/src/Concordium/Client/Output.hs
+++ b/src/Concordium/Client/Output.hs
@@ -39,6 +39,7 @@ import Codec.CBOR.Read
 import Concordium.Client.Types.Contract.BuildInfo (showBuildInfo)
 import Concordium.Common.Time (DurationSeconds (durationSeconds))
 import Concordium.Types.Execution (Event (ecEvents))
+import Control.Monad
 import Control.Monad.Writer
 import qualified Data.Aeson as AE
 import qualified Data.Aeson.Types as AE

--- a/src/Concordium/Client/Runner.hs
+++ b/src/Concordium/Client/Runner.hs
@@ -83,8 +83,9 @@ import Concordium.Client.Types.Contract.BuildInfo (extractBuildInfo)
 import Control.Arrow (Arrow (second))
 import Control.Concurrent (threadDelay)
 import Control.Exception
+import Control.Monad
 import Control.Monad.Except
-import Control.Monad.Reader hiding (fail)
+import Control.Monad.Reader
 import Control.Monad.State.Strict
 import Data.Aeson as AE
 import qualified Data.Aeson.Encode.Pretty as AE
@@ -163,12 +164,12 @@ getFromJsonAndHandleError ::
     (Value -> String -> m a) ->
     Either String Value ->
     m a
-getFromJsonAndHandleError handleError r = do
+getFromJsonAndHandleError errHandler r = do
     s <- case r of
         Left err -> logFatal [printf "I/O error: %s" err]
         Right v -> return v
     case fromJSON s of
-        Error err -> handleError s err
+        Error err -> errHandler s err
         Success v -> return v
 
 -- | Look up account from the provided name or address.

--- a/src/Concordium/Client/Types/Account.hs
+++ b/src/Concordium/Client/Types/Account.hs
@@ -9,6 +9,7 @@ module Concordium.Client.Types.Account (
 import Control.Exception
 import Control.Monad
 import Control.Monad.Except
+import Control.Monad.IO.Class
 
 import Data.Aeson ((.!=), (.:), (.:?), (.=))
 import qualified Data.Aeson as AE

--- a/src/Concordium/Client/Types/Contract/Info.hs
+++ b/src/Concordium/Client/Types/Contract/Info.hs
@@ -32,7 +32,7 @@ import Concordium.Client.Cli
 import qualified Concordium.Client.Config as Config
 import Concordium.Client.GRPC2 (ClientMonad)
 import Concordium.Client.Types.Contract.BuildInfo
-import Control.Monad.Cont (MonadIO)
+import Control.Monad.IO.Class (MonadIO)
 import Data.Aeson ((.:))
 import qualified Data.Aeson as AE
 import qualified Data.Aeson.KeyMap as KM

--- a/src/Concordium/Client/Types/TransactionStatus.hs
+++ b/src/Concordium/Client/Types/TransactionStatus.hs
@@ -3,7 +3,7 @@
 
 module Concordium.Client.Types.TransactionStatus where
 
-import Control.Monad.State (foldM)
+import Control.Monad (foldM)
 import Data.Aeson
 import Data.Aeson.TH
 import qualified Data.Map.Strict as Map

--- a/stack.linux-static.yaml
+++ b/stack.linux-static.yaml
@@ -1,4 +1,4 @@
-resolver: lts-20.16
+resolver: lts-22.9
 
 packages:
 - .

--- a/stack.linux-static.yaml
+++ b/stack.linux-static.yaml
@@ -6,14 +6,18 @@ packages:
 extra-deps:
 # http2-client was never included in stackage
 - github: Concordium/http2-client
-  commit: 4e9058db74e7a27dee0c92c4a754086e8a45a592
+  commit: af0edc5fba5265ba9a4b2f91cfc3c466e4c82197
 
 - github: Concordium/http2-grpc-haskell
-  commit: e52874ac2923f5177696e6dd4251fdb0f7dda87b
+  commit: 61fe303559bab35bc8da0ead4b41448f84b529b2
   subdirs:
     - http2-client-grpc
     - http2-grpc-proto-lens
     - http2-grpc-types
+
+- proto-lens-setup-0.4.0.7@sha256:acca0b04e033ea0a017f809d91a7dbc942e025ec6bc275fa21647352722c74cc,3122
+- proto-lens-protoc-0.8.0.0@sha256:a146ee8c9af9e445ab05651e688deb0ff849357d320657d6cea5be33cb54b960,2235
+- ghc-source-gen-0.4.4.0@sha256:8499f23c5989c295f3b002ad92784ca5fed5260fd4891dc816f17d30c5ba9cd9,4236
 
 - ./deps/concordium-base
 

--- a/stack.yaml
+++ b/stack.yaml
@@ -17,7 +17,7 @@
 #
 # resolver: ./custom-snapshot.yaml
 # resolver: https://example.com/snapshots/2018-01-01.yaml
-resolver: lts-20.16
+resolver: lts-22.9
 
 # User packages to be built.
 # Various formats can be used as shown in the example below.
@@ -42,14 +42,18 @@ packages:
 extra-deps:
 # http2-client was never included in stackage
 - github: Concordium/http2-client
-  commit: 4e9058db74e7a27dee0c92c4a754086e8a45a592
+  commit: af0edc5fba5265ba9a4b2f91cfc3c466e4c82197
 
 - github: Concordium/http2-grpc-haskell
-  commit: e52874ac2923f5177696e6dd4251fdb0f7dda87b
+  commit: 61fe303559bab35bc8da0ead4b41448f84b529b2
   subdirs:
     - http2-client-grpc
     - http2-grpc-proto-lens
     - http2-grpc-types
+
+- proto-lens-setup-0.4.0.7@sha256:acca0b04e033ea0a017f809d91a7dbc942e025ec6bc275fa21647352722c74cc,3122
+- proto-lens-protoc-0.8.0.0@sha256:a146ee8c9af9e445ab05651e688deb0ff849357d320657d6cea5be33cb54b960,2235
+- ghc-source-gen-0.4.4.0@sha256:8499f23c5989c295f3b002ad92784ca5fed5260fd4891dc816f17d30c5ba9cd9,4236
 
 - ./deps/concordium-base
 

--- a/test/SimpleClientTests/AccountSpec.hs
+++ b/test/SimpleClientTests/AccountSpec.hs
@@ -20,6 +20,7 @@ import Concordium.Types.Accounts
 import Concordium.Types.Accounts.Releases
 import Concordium.Types.Execution (DelegationTarget (..), OpenStatus (..))
 
+import Control.Monad
 import Control.Monad.Writer
 import qualified Data.Aeson as AE
 import qualified Data.Map.Strict as Map

--- a/test/SimpleClientTests/SchemaParsingSpec.hs
+++ b/test/SimpleClientTests/SchemaParsingSpec.hs
@@ -10,7 +10,7 @@ import qualified Data.ByteString as BS
 import Concordium.Client.Types.Contract.Parameter
 import Concordium.Client.Types.Contract.Schema
 
-import Control.Monad.List (forM, forM_, when)
+import Control.Monad (forM, forM_, when)
 import Data.Serialize (runPut)
 import Test.HUnit
 import Test.Hspec


### PR DESCRIPTION
## Purpose

Update to GHC 9.6.4, LTS 22.9

## Changes

- Library changes:
  - Replace deprecated `Text.PrettyPrint.ANSI.Leijen` with `Prettyprinter`.
  - Monad interface changes.
- Support protocol P7.
- Update http2-client and http2-grpc-haskell dependencies.
- Fix alpine version for linux build.
- Bump version number to 6.3.0

## Checklist

- [X] My code follows the style of this project.
- [X] The code compiles without warnings.
- [X] I have performed a self-review of the changes.
- [X] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [X] (If necessary) I have updated the CHANGELOG.
