### PR TITLE
Update rust 1.73

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -33,7 +33,7 @@ on:
   workflow_dispatch: # allow manual trigger
 
 env:
-  RUST: 1.68
+  RUST: 1.73
   GHC: 9.6.4
 
 jobs:

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 - Update GHC version to 9.6.4 (lts-22.9).
+- Update Rust version to 1.73.
 - Support protocol version 7.
 
 ## 6.2.1

--- a/README.md
+++ b/README.md
@@ -50,14 +50,14 @@ To build the tool from source, you need the following prerequisites:
     - Unix: `curl -sSL https://get.haskellstack.org/ | sh`
     - Windows: [Follow the Stack install guide](https://docs.haskellstack.org/en/stable/install_and_upgrade/).
 
-- Install Rust version 1.68+:
+- Install Rust version 1.73+:
   - Unix: `curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh`
   - Windows: [Follow the Rust install
      guide](https://www.rust-lang.org/tools/install)
     - Use the `x86_64-pc-windows-gnu` toolchain by choosing it during
        installation or by running `rustup toolchain default
        stable-x86_64-pc-windows-gnu`.
-  - *Recommended after installing: Set the default Rust version to 1.68 by running `rustup default 1.68`*.
+  - *Recommended after installing: Set the default Rust version to 1.73 by running `rustup default 1.73`*.
 
 - Install the [protoc](https://github.com/google/proto-lens/blob/master/docs/installing-protoc.md) tool for generating protobuf files:
   - MacOS: `brew install protobuf`

--- a/concordium-client.cabal
+++ b/concordium-client.cabal
@@ -5,7 +5,7 @@ cabal-version: 1.24
 -- see: https://github.com/sol/hpack
 
 name:           concordium-client
-version:        6.3.0
+version:        6.2.1
 description:    Please see the README on GitHub at <https://github.com/Concordium/concordium-client#readme>
 homepage:       https://github.com/Concordium/concordium-client#readme
 bug-reports:    https://github.com/Concordium/concordium-client/issues

--- a/scripts/distributables/linux-distributable-concordium-client.Dockerfile
+++ b/scripts/distributables/linux-distributable-concordium-client.Dockerfile
@@ -10,7 +10,7 @@ COPY . /build
 
 RUN apk add perl g++ make protoc ncurses ncurses-dev zlib zlib-static zlib-dev git wget postgresql-dev gmp-dev gmp xz
 
-ARG RUST_VERSION=1.68
+ARG RUST_VERSION=1.73
 RUN wget -qO - https://sh.rustup.rs | sh -s -- --profile minimal --default-toolchain ${RUST_VERSION} -y
 
 ARG GHC_VERSION=9.6.4

--- a/scripts/distributables/macos-concordium-client.Jenkinsfile
+++ b/scripts/distributables/macos-concordium-client.Jenkinsfile
@@ -2,7 +2,7 @@ pipeline {
     agent { label 'jenkins-worker' }
     environment {
         GHC_VERSION = '9.6.4'
-        RUST_VERSION = '1.68'
+        RUST_VERSION = '1.73'
         VERSION = sh(
             returnStdout: true,
             script: '''\

--- a/scripts/distributables/windows-concordium-client.Jenkinsfile
+++ b/scripts/distributables/windows-concordium-client.Jenkinsfile
@@ -30,7 +30,7 @@ pipeline {
                     # Zip the binaries
                     mkdir out
                     binDir=$(stack path --local-install-root)/bin
-                    (cd $binDir && powershell -Command "Compress-Archive -Path concordium-client.exe,concordium_base.dll,sha_2.dll -DestinationPath concordium-client.zip)
+                    (cd $binDir && powershell -Command "Compress-Archive -Path concordium-client.exe,concordium_base.dll,sha_2.dll -DestinationPath concordium-client.zip")
                     mv -f $binDir/concordium-client.zip out/concordium-client.zip
 
                     # Push to s3

--- a/scripts/distributables/windows-concordium-client.Jenkinsfile
+++ b/scripts/distributables/windows-concordium-client.Jenkinsfile
@@ -27,10 +27,11 @@ pipeline {
                     # Build project
                     stack build --force-dirty
                     
+                    # Zip the binaries
                     mkdir out
                     binDir=$(stack path --local-install-root)/bin
-                    outDir=$(pwd)/out
-                    (cd $binDir && zip $outDir/concordium-client.zip concordium-client.exe concordium_base.dll sha_2.dll)
+                    (cd $binDir && powershell -Command "Compress-Archive -Path concordium-client.exe,concordium_base.dll,sha_2.dll -DestinationPath concordium-client.zip)
+                    mv -f $binDir/concordium-client.zip out/concordium-client.zip
 
                     # Push to s3
                     aws s3 cp out/concordium-client.zip ${OUTFILE} --grants read=uri=http://acs.amazonaws.com/groups/global/AllUsers


### PR DESCRIPTION
## Purpose

Update the client to support Rust version 1.73

## Changes

- Update Rust version
- Roll-back version number, since there wasn't a 6.3.0 release.
- Build produces a zip file including `concordium-client.exe` and dependency DLLs on Windows.

## Checklist

- [X] My code follows the style of this project.
- [x] The code compiles without warnings.
- [X] I have performed a self-review of the changes.
- [X] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [X] (If necessary) I have updated the CHANGELOG.
