### PR TITLE
Remove shielded transfers

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -2,9 +2,11 @@
 
 ## Unreleased
 
-- Rename subcommand `TransactionSubmit` to `TransactionSignAndSubmit`.
-- Add subcommand `TransactionSubmit` to submit a signed transaction on chain.
-- Add subcommand `TransactionAddSignature` to add a signature to a partially-signed transaction.
+- Remove command `transaction send-shielded` to disable the transfer of CCD from the shielded balance of the account to the shielded balance of another account.
+- Remove command `account shield` to disable the transfer of CCD from the public balance to the shielded balance of an account.
+- Rename command `transaction submit` to `transaction sign-and-submit`.
+- Add command `transaction submit` to submit a signed transaction on chain.
+- Add command `transaction add-signature` to add a signature to a partially-signed transaction.
 - Add optional `--out` flag to all transaction-creating commands to output a partially-singed transaction to a file.
 - Update GHC version to 9.6.4 (lts-22.9).
 - Update Rust version to 1.73.


### PR DESCRIPTION
## Purpose

closes #304 

## Changes

- Remove command `transaction send-shielded` to disable the transfer of CCD from the shielded balance of the account to the shielded balance of another account.
- Remove command `account shield` to disable the transfer of CCD from the public balance to the shielded balance of an account.