### PR TITLE
Remove command transactionSignAndSubmit

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Remove command `transaction sign-and-submit`.
 - Remove command `transaction send-shielded` to disable the transfer of CCD from the shielded balance of the account to the shielded balance of another account.
 - Remove command `account shield` to disable the transfer of CCD from the public balance to the shielded balance of an account.
 - Rename command `transaction submit` to `transaction sign-and-submit`.

--- a/src/Concordium/Client/Commands.hs
+++ b/src/Concordium/Client/Commands.hs
@@ -181,11 +181,7 @@ registerDataParser =
         <|> (RegisterRaw <$> strOption (long "raw" <> metavar "FILE" <> help "File with raw bytes to be registered on chain."))
 
 data TransactionCmd
-    = TransactionSignAndSubmit
-        { tssFile :: !FilePath,
-          tssInteractionOpts :: !InteractionOpts
-        }
-    | TransactionSubmit
+    = TransactionSubmit
         { tsFile :: !FilePath,
           tsInteractionOpts :: !InteractionOpts
         }
@@ -695,8 +691,7 @@ transactionCmds =
         ( info
             ( TransactionCmd
                 <$> hsubparser
-                    ( transactionSignAndSubmitCmd
-                        <> transactionSubmitCmd
+                    ( transactionSubmitCmd
                         <> transactionAddSignatureCmd
                         <> transactionStatusCmd
                         <> transactionSendCcdCmd
@@ -706,18 +701,6 @@ transactionCmds =
                     )
             )
             (progDesc "Commands for submitting and inspecting transactions.")
-        )
-
-transactionSignAndSubmitCmd :: Mod CommandFields TransactionCmd
-transactionSignAndSubmitCmd =
-    command
-        "sign-and-submit"
-        ( info
-            ( TransactionSignAndSubmit
-                <$> strArgument (metavar "FILE" <> help "File containing the transaction parameters in JSON format.")
-                <*> interactionOptsParser
-            )
-            (progDesc "Parse a JSON transaction with keys, sign it, and send it to the node.")
         )
 
 transactionSubmitCmd :: Mod CommandFields TransactionCmd

--- a/src/Concordium/Client/Runner.hs
+++ b/src/Concordium/Client/Runner.hs
@@ -687,22 +687,6 @@ readSignedTransactionFromFile fname = do
 processTransactionCmd :: TransactionCmd -> Maybe FilePath -> Verbose -> Backend -> IO ()
 processTransactionCmd action baseCfgDir verbose backend =
     case action of
-        TransactionSignAndSubmit fname intOpts -> do
-            -- TODO Ensure that the "nonce" field is optional in the payload.
-            source <- handleReadFile BSL.readFile fname
-
-            -- TODO Print transaction details
-
-            when (ioConfirm intOpts) $ do
-                confirmed <- askConfirmation $ Just "Do you want to send the transaction on chain? "
-                unless confirmed exitTransactionCancelled
-
-            withClient backend $ do
-                tx <- processTransaction source
-                let hash = getBlockItemHash tx
-                logSuccess [printf "transaction '%s' sent to the node" (show hash)]
-                when (ioTail intOpts) $ do
-                    tailTransaction_ verbose hash
         TransactionSubmit fname intOpts -> do
             -- Read signedTransaction from file
             signedTransaction <- readSignedTransactionFromFile fname


### PR DESCRIPTION
## Purpose

closes #306 

Under the subcommand `raw/legacy`, the sending of a transaction from a FILE given some keys for signing is still available.


## Changes

Remove command `transaction sign-and-submit`


