### PR TITLE
Fix expiry time for pending stake changes

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -3,6 +3,8 @@
 ## Unreleased
 
 - Support node version 7 and protocol version 7.
+- Fix the display of the expected expiry of pending changes to an account's stake, so that they
+  correctly account for the change taking place at a payday.
 
 ## 6.3.0
 


### PR DESCRIPTION
## Purpose

Fixes #142 #149

This fixes the expiry time that is presented to the user for pending stake changes. This affects both when the user reduces the stake (and the expected expiry time is shown to them) and when the user views the state of an account with a pending change.

## Changes

- Revise `getBakerCooldown` and `getDelegatorCooldown` to start the cooldown from the next payday. (We assume that the cooldown duration is a multiple of the payday length for the calculation to be accurate, but we generally ensure this fact.)
- Introduce `correctPendingChange` to correct the pending change on an account (if applicable).
- Apply the correction when displaying account info.

## Checklist

- [X] My code follows the style of this project.
- [X] The code compiles without warnings.
- [X] I have performed a self-review of the changes.
- [X] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [X] (If necessary) I have updated the CHANGELOG.
