### PR TITLE
Show cooldown info on accounts.

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -3,6 +3,10 @@
 ## Unreleased
 
 - Support node version 7 and protocol version 7.
+  - Display account balance "at disposal". (Note, this will (incorrectly) show as 0 if connecting to
+    an older version of the node.)
+  - List the cooldowns on an account, and their expiration times.
+- Improved checks when configuring a validator or delegator.
 
 ## 6.3.0
 

--- a/test/SimpleClientTests/AccountSpec.hs
+++ b/test/SimpleClientTests/AccountSpec.hs
@@ -107,7 +107,13 @@ exampleDelegatorStakingInfo pc =
 
 -- The credentials will be given indices 0, 1, ..
 exampleAccountInfoResult :: AccountStakingInfo -> [IDTypes.RawAccountCredential] -> AccountInfo
-exampleAccountInfoResult staking cs =
+exampleAccountInfoResult = exampleAccountInfoResultWithCooldowns []
+
+exampleCooldowns :: [Cooldown]
+exampleCooldowns = [Cooldown 3600000 200 StatusCooldown, Cooldown 7200000 400 StatusPreCooldown, Cooldown 9000000 500 StatusPrePreCooldown]
+
+exampleAccountInfoResultWithCooldowns :: [Cooldown] -> AccountStakingInfo -> [IDTypes.RawAccountCredential] -> AccountInfo
+exampleAccountInfoResultWithCooldowns cooldowns staking cs =
     AccountInfo
         { aiAccountAmount = Types.Amount 1,
           aiAccountNonce = Types.Nonce 2,
@@ -125,7 +131,7 @@ exampleAccountInfoResult staking cs =
           aiAccountEncryptionKey = dummyEncryptionPublicKey,
           aiAccountIndex = 27,
           aiAccountAddress = exampleAddress1,
-          aiAccountCooldowns = [],
+          aiAccountCooldowns = cooldowns,
           aiAccountAvailableAmount = Types.Amount 1
         }
 
@@ -231,6 +237,7 @@ printAccountInfoSpec = describe "printAccountInfo" $ do
             `shouldBe` [ "Local names:            'example'",
                          "Address:                2zR4h351M1bqhrL9UywsbHrP3ucA1xY3TBTFRuTsRout8JnLD6",
                          "Balance:                0.000001 CCD",
+                         " - At disposal:         0.000001 CCD",
                          "Nonce:                  2",
                          "Encryption public key:  a820662531d0aac70b3a80dd8a249aa692436097d06da005aec7c56aad17997ec8331d1e4050fd8dced2b92f06277bd5aae71cf315a6d70c849508f6361ac6d51c2168305dd1604c4c6448da4499b2f14afb94fff0f42b79a68ed7ba206301f4",
                          "",
@@ -243,6 +250,7 @@ printAccountInfoSpec = describe "printAccountInfo" $ do
             `shouldBe` [ "Local names:            'example'",
                          "Address:                2zR4h351M1bqhrL9UywsbHrP3ucA1xY3TBTFRuTsRout8JnLD6",
                          "Balance:                0.000001 CCD",
+                         " - At disposal:         0.000001 CCD",
                          "Nonce:                  2",
                          "Encryption public key:  a820662531d0aac70b3a80dd8a249aa692436097d06da005aec7c56aad17997ec8331d1e4050fd8dced2b92f06277bd5aae71cf315a6d70c849508f6361ac6d51c2168305dd1604c4c6448da4499b2f14afb94fff0f42b79a68ed7ba206301f4",
                          "",
@@ -257,6 +265,7 @@ printAccountInfoSpec = describe "printAccountInfo" $ do
             `shouldBe` [ "Local names:            'example'",
                          "Address:                2zR4h351M1bqhrL9UywsbHrP3ucA1xY3TBTFRuTsRout8JnLD6",
                          "Balance:                0.000001 CCD",
+                         " - At disposal:         0.000001 CCD",
                          "Nonce:                  2",
                          "Encryption public key:  a820662531d0aac70b3a80dd8a249aa692436097d06da005aec7c56aad17997ec8331d1e4050fd8dced2b92f06277bd5aae71cf315a6d70c849508f6361ac6d51c2168305dd1604c4c6448da4499b2f14afb94fff0f42b79a68ed7ba206301f4",
                          "",
@@ -264,6 +273,26 @@ printAccountInfoSpec = describe "printAccountInfo" $ do
                          "Delegation target: Passive delegation",
                          " - Staked amount: 0.000100 CCD",
                          " - Restake earnings: no",
+                         "",
+                         "Credentials: none"
+                       ]
+    specify "with delegator & cooldown" $
+        p exampleNamedAddress (exampleAccountInfoResultWithCooldowns exampleCooldowns (exampleDelegatorStakingInfo NoChange) [])
+            `shouldBe` [ "Local names:            'example'",
+                         "Address:                2zR4h351M1bqhrL9UywsbHrP3ucA1xY3TBTFRuTsRout8JnLD6",
+                         "Balance:                0.000001 CCD",
+                         " - At disposal:         0.000001 CCD",
+                         "Nonce:                  2",
+                         "Encryption public key:  a820662531d0aac70b3a80dd8a249aa692436097d06da005aec7c56aad17997ec8331d1e4050fd8dced2b92f06277bd5aae71cf315a6d70c849508f6361ac6d51c2168305dd1604c4c6448da4499b2f14afb94fff0f42b79a68ed7ba206301f4",
+                         "",
+                         "Delegating stake: yes",
+                         "Delegation target: Passive delegation",
+                         " - Staked amount: 0.000100 CCD",
+                         " - Restake earnings: no",
+                         "Inactive stake in cooldown:",
+                         "   0.000200 CCD available after Thu,  1 Jan 1970 01:00:00 UTC",
+                         "   0.000400 CCD available after Thu,  1 Jan 1970 02:00:00 UTC",
+                         "   0.000500 CCD available after Thu,  1 Jan 1970 02:30:00 UTC",
                          "",
                          "Credentials: none"
                        ]
@@ -285,6 +314,7 @@ printAccountInfoSpec = describe "printAccountInfo" $ do
             `shouldBe` [ "Local names:            'example'",
                          "Address:                2zR4h351M1bqhrL9UywsbHrP3ucA1xY3TBTFRuTsRout8JnLD6",
                          "Balance:                0.000001 CCD",
+                         " - At disposal:         0.000001 CCD",
                          "Release schedule:       total 0.000100 CCD",
                          "   Tue,  3 Nov 2020 15:28:22 UTC:               0.000033 CCD scheduled by the transactions: f26a45adbb7d5cbefd9430d1eac665bd225fb3d8e04efb288d99a0347f0b8868, b041315fe35a8bdf836647037c24c8e87402547c82aea568c66ee18aa3091326.",
                          "   Tue,  3 Nov 2020 15:29:02 UTC:               0.000033 CCD scheduled by the transactions: f26a45adbb7d5cbefd9430d1eac665bd225fb3d8e04efb288d99a0347f0b8868.",
@@ -301,6 +331,7 @@ printAccountInfoSpec = describe "printAccountInfo" $ do
             `shouldBe` [ "Local names:            'example'",
                          "Address:                2zR4h351M1bqhrL9UywsbHrP3ucA1xY3TBTFRuTsRout8JnLD6",
                          "Balance:                0.000001 CCD",
+                         " - At disposal:         0.000001 CCD",
                          "Nonce:                  2",
                          "Encryption public key:  a820662531d0aac70b3a80dd8a249aa692436097d06da005aec7c56aad17997ec8331d1e4050fd8dced2b92f06277bd5aae71cf315a6d70c849508f6361ac6d51c2168305dd1604c4c6448da4499b2f14afb94fff0f42b79a68ed7ba206301f4",
                          "",
@@ -325,6 +356,7 @@ printAccountInfoSpec = describe "printAccountInfo" $ do
             `shouldBe` [ "Local names:            'example'",
                          "Address:                2zR4h351M1bqhrL9UywsbHrP3ucA1xY3TBTFRuTsRout8JnLD6",
                          "Balance:                0.000001 CCD",
+                         " - At disposal:         0.000001 CCD",
                          "Nonce:                  2",
                          "Encryption public key:  a820662531d0aac70b3a80dd8a249aa692436097d06da005aec7c56aad17997ec8331d1e4050fd8dced2b92f06277bd5aae71cf315a6d70c849508f6361ac6d51c2168305dd1604c4c6448da4499b2f14afb94fff0f42b79a68ed7ba206301f4",
                          "",
@@ -347,6 +379,7 @@ printAccountInfoSpec = describe "printAccountInfo" $ do
             `shouldBe` [ "Local names:            'example'",
                          "Address:                2zR4h351M1bqhrL9UywsbHrP3ucA1xY3TBTFRuTsRout8JnLD6",
                          "Balance:                0.000001 CCD",
+                         " - At disposal:         0.000001 CCD",
                          "Nonce:                  2",
                          "Encryption public key:  a820662531d0aac70b3a80dd8a249aa692436097d06da005aec7c56aad17997ec8331d1e4050fd8dced2b92f06277bd5aae71cf315a6d70c849508f6361ac6d51c2168305dd1604c4c6448da4499b2f14afb94fff0f42b79a68ed7ba206301f4",
                          "",
@@ -378,6 +411,7 @@ printAccountInfoSpec = describe "printAccountInfo" $ do
             `shouldBe` [ "Local names:            'example'",
                          "Address:                2zR4h351M1bqhrL9UywsbHrP3ucA1xY3TBTFRuTsRout8JnLD6",
                          "Balance:                0.000001 CCD",
+                         " - At disposal:         0.000001 CCD",
                          "Nonce:                  2",
                          "Encryption public key:  a820662531d0aac70b3a80dd8a249aa692436097d06da005aec7c56aad17997ec8331d1e4050fd8dced2b92f06277bd5aae71cf315a6d70c849508f6361ac6d51c2168305dd1604c4c6448da4499b2f14afb94fff0f42b79a68ed7ba206301f4",
                          "",
@@ -401,6 +435,7 @@ printAccountInfoSpec = describe "printAccountInfo" $ do
             `shouldBe` [ "Local names:            'example'",
                          "Address:                2zR4h351M1bqhrL9UywsbHrP3ucA1xY3TBTFRuTsRout8JnLD6",
                          "Balance:                0.000001 CCD",
+                         " - At disposal:         0.000001 CCD",
                          "Nonce:                  2",
                          "Encryption public key:  a820662531d0aac70b3a80dd8a249aa692436097d06da005aec7c56aad17997ec8331d1e4050fd8dced2b92f06277bd5aae71cf315a6d70c849508f6361ac6d51c2168305dd1604c4c6448da4499b2f14afb94fff0f42b79a68ed7ba206301f4",
                          "",


### PR DESCRIPTION
## Purpose

Closes #297

This supports cooldowns by updating how account information is shown to include cooldown status. Since it is permissible (from P7) to transition directly between baker and delegator, the required fields for configuring the baker and delegator are different in these cases (namely, you don't need to specify the stake and whether to restake).

## Changes

- Display available balance returned by the node.
- Display the list of cooldowns on an account.
- When becoming a delegator, check that the necessary fields are provided.
- When becoming a validator, check that the necessary fields are provided.
- Update tests.

## Checklist

- [X] My code follows the style of this project.
- [X] The code compiles without warnings.
- [X] I have performed a self-review of the changes.
- [X] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [X] (If necessary) I have updated the CHANGELOG.
