### PR TITLE
Report correct available balance with node version < 7.

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Display the correct "at disposal" balance when used with node versions prior to 7.
+
 ## 7.0.0
 
 - Support node version 7 and protocol version 7.


### PR DESCRIPTION
## Purpose

For node version < 7, the available balance on an account is not returned in the `GetAccountInfo` query response. This change checks if that is the case and computes the correct balance, instead of simply returning 0.

The main purpose of this is to support the wallet proxy, allowing us to deploy it before node version 7 is deployed.

## Changes

- Revise the `FromProto` implementation for `AccountInfo` to calculate the available amount if it is not present in the protobuf.

## Checklist

- [X] My code follows the style of this project.
- [X] The code compiles without warnings.
- [X] I have performed a self-review of the changes.
- [X] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [X] (If necessary) I have updated the CHANGELOG.
