### PR TITLE
Support for GetConsensusDetailedStatus.

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+- Add command `consensus detailed-status` for getting detailed consensus status (from protocol
+  version 6).
+- Add `raw GetConsensusDetailedStatus` that presents the detailed consensus status as JSON.
+
 ## 7.0.1
 
 - Display the correct "at disposal" balance when used with node versions prior to 7.

--- a/concordium-client.cabal
+++ b/concordium-client.cabal
@@ -47,6 +47,7 @@ library
       Concordium.Client.Runner.Helper
       Concordium.Client.RWLock
       Concordium.Client.Types.Account
+      Concordium.Client.Types.ConsensusStatus
       Concordium.Client.Types.Contract.BuildInfo
       Concordium.Client.Types.Contract.Info
       Concordium.Client.Types.Contract.Parameter

--- a/src/Concordium/Client/Commands.hs
+++ b/src/Concordium/Client/Commands.hs
@@ -439,6 +439,9 @@ data ConsensusCmd
           ccuKeys :: ![FilePath],
           ccuInteractionOpts :: !InteractionOpts
         }
+    | ConsensusDetailedStatus
+        { cdsGenesisIndex :: !(Maybe GenesisIndex)
+        }
     deriving (Show)
 
 data BlockCmd = BlockShow
@@ -1560,6 +1563,7 @@ consensusCmds =
             ( ConsensusCmd
                 <$> ( hsubparser
                         ( consensusStatusCmd
+                            <> consensusDetailedStatusCmd
                             <> consensusShowChainParametersCmd
                             <> consensusShowParametersCmd
                         )
@@ -1577,6 +1581,17 @@ consensusStatusCmd =
         ( info
             (pure ConsensusStatus)
             (progDesc "List various parameters related to the current state of the consensus protocol.")
+        )
+
+consensusDetailedStatusCmd :: Mod CommandFields ConsensusCmd
+consensusDetailedStatusCmd =
+    command
+        "detailed-status"
+        ( info
+            ( ConsensusDetailedStatus
+                <$> optional (option auto (long "genesis-index" <> metavar "GENINDEX" <> help "Genesis index (defaults to latest)"))
+            )
+            (progDesc "Show detailed consensus status information.")
         )
 
 consensusShowParametersCmd :: Mod CommandFields ConsensusCmd

--- a/src/Concordium/Client/LegacyCommands.hs
+++ b/src/Concordium/Client/LegacyCommands.hs
@@ -42,6 +42,8 @@ data LegacyCmd
         }
     | -- | Queries the gRPC server for the consensus information
       GetConsensusInfo
+    | -- | Queries the gRPC server for detailed consensus status
+      GetConsensusDetailedStatus {legacyFromGenesisIndex :: !(Maybe GenesisIndex)}
     | -- | Queries the gRPC server for the information of a specific block
       GetBlockInfo
         { legacyEvery :: !Bool,
@@ -174,6 +176,7 @@ legacyProgramOptions =
     hsubparser
         ( getTransactionStatusCommand
             <> getConsensusInfoCommand
+            <> getConsensusDetailedStatusCommand
             <> getBlockInfoCommand
             <> getBlockPendingUpdatesCommand
             <> getBlockTransactionEventsCommand
@@ -263,6 +266,17 @@ getConsensusInfoCommand =
         ( info
             (pure GetConsensusInfo)
             (progDesc "Query the gRPC server for the consensus information.")
+        )
+
+getConsensusDetailedStatusCommand :: Mod CommandFields LegacyCmd
+getConsensusDetailedStatusCommand =
+    command
+        "GetConsensusDetailedStatus"
+        ( info
+            ( GetConsensusDetailedStatus
+                <$> optional (option auto (long "genesis-index" <> metavar "GENINDEX" <> help "Consensus genesis index"))
+            )
+            (progDesc "Query the gRPC server for the detailed consensus status. If the genesis index is not specified, the current one is used.")
         )
 
 getBlockInfoCommand :: Mod CommandFields LegacyCmd

--- a/src/Concordium/Client/Output.hs
+++ b/src/Concordium/Client/Output.hs
@@ -27,6 +27,7 @@ import qualified Concordium.ID.Types as IDTypes
 import qualified Concordium.Types as Types
 import qualified Concordium.Types.Accounts as Types
 import qualified Concordium.Types.Accounts.Releases as Types
+import qualified Concordium.Types.Block as Types
 import qualified Concordium.Types.Execution as Types
 import Concordium.Types.Parameters
 import Concordium.Types.ProtocolVersion
@@ -36,6 +37,8 @@ import qualified Concordium.Wasm as Wasm
 import Codec.CBOR.Decoding (decodeString)
 import Codec.CBOR.JSON
 import Codec.CBOR.Read
+
+import qualified Concordium.Client.Types.ConsensusStatus as ConsensusStatus
 import Concordium.Client.Types.Contract.BuildInfo (showBuildInfo)
 import Concordium.Common.Time (DurationSeconds (durationSeconds))
 import Concordium.Types.Execution (Event (ecEvents))
@@ -49,7 +52,7 @@ import qualified Data.ByteString.Lazy as BSL
 import qualified Data.ByteString.Short as BSS
 import Data.Either (isRight)
 import Data.Functor
-import Data.List (foldl', intercalate, nub, partition, sortOn)
+import Data.List (elemIndex, foldl', intercalate, nub, partition, sortOn)
 import qualified Data.Map.Strict as Map
 import Data.Maybe
 import Data.Ratio
@@ -1488,3 +1491,137 @@ unwrapMaybeList = concat
 showConditionally :: (Show a) => Conditionally b a -> String
 showConditionally (CFalse) = "N/A"
 showConditionally (CTrue v) = show v
+
+-- | Render the detailed consensus status.
+printConsensusDetailedStatus :: ConsensusStatus.ConsensusDetailedStatus -> Printer
+printConsensusDetailedStatus ConsensusStatus.ConsensusDetailedStatus{..} = do
+    tell
+        [ [i|Current era genesis block: #{cdsGenesisBlock} (height #{cdsGenesisBlockHeight})|]
+        ]
+    forM_ cdsTerminalBlock $ \tb -> tell [[i|Terminal block:            #{tb}|]]
+    let ConsensusStatus.RoundStatus{..} = cdsRoundStatus
+    let eligible
+            | rsRoundEligibleToBake = "not tried to bake" :: String
+            | otherwise = "already tried to bake"
+    tell
+        [ [i|Current round: #{rsCurrentRound} (#{eligible})|],
+          [i|Current epoch: #{rsCurrentEpoch}|],
+          [i|Highest certified block:|]
+        ]
+    tell $ renderQC rsHighestCertifiedBlock
+    forM_ rsPreviousRoundTimeout $ tell . ([i|Previous round timeout:|] :) . renderRoundTimeout
+    tell [[i|Current timeout duration: #{showDuration (Types.durationMillis rsCurrentTimeout)}|]]
+    let ConsensusStatus.PersistentRoundStatus{..} = cdsPersistentRoundStatus
+    forM_ prsLastSignedQuorumMessage $ \ConsensusStatus.QuorumMessage{..} ->
+        tell
+            [ [i|Last signed quorum message:|],
+              [i|  Block:           #{qmBlock}|],
+              [i|  Finalizer index: #{qmFinalizer}|],
+              [i|  Round:           #{qmRound}|],
+              [i|  Epoch:           #{qmEpoch}|]
+            ]
+    forM_ prsLastSignedTimeoutMessage $ \ConsensusStatus.TimeoutMessage{..} ->
+        tell $
+            [ [i|Last signed timeout message:|],
+              [i|  Finalizer index: #{tmFinalizer}|],
+              [i|  Round:           #{tmRound}|],
+              [i|  Epoch:           #{tmEpoch}|],
+              [i|  Highest quorum certificate:|]
+            ]
+                <> (("  " <>) <$> renderQC tmQuorumCertificate)
+    tell [[i|Last baked round: #{prsLastBakedRound}|]]
+    forM_ prsLatestTimeout $ \tc ->
+        tell $ [i|Latest timeout certificate:|] : renderTC tc
+    forM_ rsLastEpochFinalizationEntry $
+        tell . ([i|Last epoch finalization entry:|] :) . renderFinEntry
+    let ConsensusStatus.BlockTableSummary{..} = cdsBlockTable
+    let lfbHeight = Types.localToAbsoluteBlockHeight cdsGenesisBlockHeight cdsLastFinalizedBlockHeight
+    tell
+        [ [i|Non-finalized transactions:      #{cdsNonFinalizedTransactionCount}|],
+          [i|Transaction table purge counter: #{cdsTransactionTablePurgeCounter}|],
+          [i|Cached dead blocks:              #{btsDeadBlockCacheSize}|],
+          [i|Last finalized block:            #{cdsLastFinalizedBlock} (height #{lfbHeight})|]
+        ]
+    forM_ cdsLatestFinalizationEntry $ tell . renderFinEntry
+    tell [[i|Live blocks:                     #{length btsLiveBlocks}|]]
+    tell $ zipWith renderLiveBlocksAtHeight [lfbHeight + 1 ..] btsLiveBlocks
+    tell $ [i|Live rounds with blocks:|] : map renderRoundExistingBlock cdsRoundExistingBlocks
+    tell $ [i|Live rounds with quorum certificates:|] : map renderRoundExistingQC cdsRoundExistingQCs
+    forM_ cdsTimeoutMessages $ \ConsensusStatus.TimeoutMessages{..} -> do
+        tell $
+            [[i|Timeout messages:|], [i|  Epoch #{tmFirstEpoch}:|]]
+                ++ (renderTimeoutMessage <$> tmFirstEpochTimeouts)
+        unless (null tmSecondEpochTimeouts) $
+            tell $
+                [i|  Epoch #{tmFirstEpoch + 1}:|] : (renderTimeoutMessage <$> tmSecondEpochTimeouts)
+    let ConsensusStatus.EpochBakers{..} = cdsEpochBakers
+    tell [[i|Next payday epoch:               #{ebNextPayday}|]]
+    let lfbEpoch = case cdsLatestFinalizationEntry of
+            Nothing -> 0
+            Just fe -> ConsensusStatus.qcEpoch (ConsensusStatus.feFinalizedQC fe)
+    let epochsFirst :: String
+        epochsFirst
+            | Just _ <- ebCurrentEpochBakers = [i|epoch #{lfbEpoch - 1}|]
+            | Just _ <- ebNextEpochBakers,
+              lfbEpoch == 0 =
+                [i|epoch #{lfbEpoch}|]
+            | Just _ <- ebNextEpochBakers = [i|epochs #{lfbEpoch - 1} and #{lfbEpoch}|]
+            | lfbEpoch == 0 = [i|epochs #{lfbEpoch} and #{lfbEpoch + 1}|]
+            | otherwise = [i|epochs #{lfbEpoch - 1}, #{lfbEpoch} and #{lfbEpoch + 1}|]
+        epochsSecond :: String
+            | Just _ <- ebNextEpochBakers = [i|epoch #{lfbEpoch}|]
+            | otherwise = [i|epochs #{lfbEpoch} and #{lfbEpoch + 1}|]
+    tell $ [i|Validators for #{epochsFirst}:|] : renderBakers ebPreviousEpochBakers
+    forM_ ebCurrentEpochBakers $ \eb -> tell $ [i|Validators for #{epochsSecond}:|] : renderBakers eb
+    forM_ ebNextEpochBakers $ \eb -> tell $ [i|Validators for epoch #{lfbEpoch + 1}:|] : renderBakers eb
+  where
+    renderQC ConsensusStatus.QuorumCertificate{..} =
+        [ [i|  Block:       #{qcBlockHash}|],
+          [i|  Round:       #{qcRound}|],
+          [i|  Epoch:       #{qcEpoch}|],
+          [i|  Signatories: #{qcSignatories} |]
+        ]
+    renderTC ConsensusStatus.TimeoutCertificate{..} =
+        [ [i|  Timeout round: #{tcRound}|],
+          [i|  Finalizers in epoch #{tcMinEpoch}:|]
+        ]
+            <> (renderFinalizerRound <$> tcQcRoundsFirstEpoch)
+            <> if null tcQcRoundsSecondEpoch
+                then []
+                else
+                    [i|  Finalizers in epoch #{tcMinEpoch + 1}:|]
+                        : (renderFinalizerRound <$> tcQcRoundsSecondEpoch)
+    renderFinalizerRound ConsensusStatus.FinalizerRound{..} =
+        [i|    Round #{frRound}: #{frFinalizers}|]
+    renderRoundTimeout ConsensusStatus.RoundTimeout{..} =
+        ( [i|  Timeout certificate:|]
+            : (("  " <>) <$> renderTC rtTimeoutCertificate)
+        )
+            <> ( [i|  Highest quorum certificate:|]
+                    : (("  " <>) <$> renderQC rtQuorumCertificate)
+               )
+    renderFinEntry ConsensusStatus.FinalizationEntry{..} =
+        ([i|  Finalized block quorum certificate:|] : (("  " <>) <$> renderQC feFinalizedQC))
+            <> ([i|  Successor block quorum certificate:|] : (("  " <>) <$> renderQC feSuccessorQC))
+    renderLiveBlocksAtHeight h b = [i|  At height #{h}: #{b}|]
+    renderRoundExistingBlock ConsensusStatus.RoundExistingBlock{..} =
+        [i|  Round #{rebRound}: #{rebBlock} - baker #{rebBaker}|]
+    renderRoundExistingQC ConsensusStatus.RoundExistingQC{..} =
+        [i|  Round #{reqRound} in epoch #{reqEpoch}|]
+    renderTimeoutMessage ConsensusStatus.TimeoutMessage{..} =
+        [i|  Finalizer #{tmFinalizer} in round #{tmRound}, epoch #{tmEpoch} with highest QC round #{ConsensusStatus.qcRound tmQuorumCertificate}|]
+    renderBakers ConsensusStatus.BakersAndFinalizers{..} =
+        [i|  Validator ID    Finalizer Index            Effective Stake            Finalizer Weight|]
+            : (renderFBI <$> bafBakers)
+      where
+        finIndex bid = maybe "-" show $ elemIndex bid bafFinalizers
+        renderFBI ConsensusStatus.FullBakerInfo{..} =
+            printf
+                "  %12u    %15s    %20u (%8.4f%%)"
+                (toInteger fbiBakerIdentity)
+                (finIndex fbiBakerIdentity)
+                (Types._amount fbiStake)
+                (fromIntegral @_ @Double fbiStake / fromIntegral bafBakerTotalStake * 100)
+                <> if fbiBakerIdentity `elem` bafFinalizers
+                    then printf "          %8.4f%%" (fromIntegral @_ @Double fbiStake / fromIntegral bafFinalizerTotalStake * 100)
+                    else ""

--- a/src/Concordium/Client/Runner.hs
+++ b/src/Concordium/Client/Runner.hs
@@ -2940,6 +2940,9 @@ processConsensusCmd action _baseCfgDir verbose backend =
                         logSuccess [[i|Update instruction '#{hash}' sent to the node|]]
                         when (ioTail intOpts) $
                             tailTransaction_ verbose hash
+        ConsensusDetailedStatus mGenesisIndex -> do
+            v <- withClient backend $ getResponseValueOrDie =<< getConsensusDetailedStatus mGenesisIndex
+            runPrinter $ printConsensusDetailedStatus v
 
 -- | Process a 'block ...' command.
 processBlockCmd :: BlockCmd -> Verbose -> Backend -> IO ()
@@ -4127,6 +4130,10 @@ processLegacyCmd action backend =
         GetConsensusInfo ->
             withClient backend $
                 getConsensusInfo
+                    >>= printResponseValueAsJSON
+        GetConsensusDetailedStatus mGenesisIndex ->
+            withClient backend $
+                getConsensusDetailedStatus mGenesisIndex
                     >>= printResponseValueAsJSON
         GetBlockInfo every block ->
             withClient backend $

--- a/src/Concordium/Client/Types/ConsensusStatus.hs
+++ b/src/Concordium/Client/Types/ConsensusStatus.hs
@@ -1,0 +1,316 @@
+{-# LANGUAGE DerivingStrategies #-}
+{-# LANGUAGE TemplateHaskell #-}
+
+module Concordium.Client.Types.ConsensusStatus where
+
+import Data.Aeson
+import Data.Aeson.TH
+import Data.Char (isLower)
+import Data.Int
+import Data.Word
+
+import qualified Concordium.Crypto.BlockSignature as BlockSignature
+import qualified Concordium.Crypto.BlsSignature as Bls
+import qualified Concordium.Crypto.SHA256 as Hash
+import qualified Concordium.Crypto.VRF as VRF
+import Concordium.Types
+import Concordium.Types.Block
+import Concordium.Types.Queries.KonsensusV1 hiding (
+    FinalizerRound,
+    QuorumCertificate,
+    TimeoutCertificate,
+ )
+import Concordium.Utils
+
+-- | Index of a finalizer in the finalization committee vector.
+newtype FinalizerIndex = FinalizerIndex {theFinalizerIndex :: Word32}
+    deriving newtype (Eq, Ord, Show, ToJSON, FromJSON)
+
+-- | The message that is multicast by a finalizer when validating and signing a block.
+data QuorumMessage = QuorumMessage
+    { -- | Signature on the relevant quorum signature message.
+      qmSignature :: !QuorumCertificateSignature,
+      -- | Hash of the block that is signed.
+      qmBlock :: !BlockHash,
+      -- | Index of the finalizer signing the message.
+      qmFinalizer :: !FinalizerIndex,
+      -- | Round of the block.
+      qmRound :: !Round,
+      -- | Epoch of the block.
+      qmEpoch :: !Epoch
+    }
+    deriving (Eq, Show)
+
+$(deriveJSON defaultOptions{fieldLabelModifier = firstLower . dropWhile isLower} ''QuorumMessage)
+
+data QuorumCertificate = QuorumCertificate
+    { -- | The hash of the block that the quorum certificate refers to.
+      qcBlockHash :: !BlockHash,
+      -- | The round of the block.
+      qcRound :: !Round,
+      -- | The epoch of the block.
+      qcEpoch :: !Epoch,
+      -- | The aggregated signature by the finalization committee on the block.
+      qcAggregateSignature :: !QuorumCertificateSignature,
+      -- | A list of the finalizers that formed the quorum certificate
+      -- i.e., the ones who have contributed to the 'aggregate_siganture'.
+      -- The finalizers are identified by their finalizer index, which refers to the
+      -- finalization committee for the epoch.
+      qcSignatories :: ![FinalizerIndex]
+    }
+    deriving (Eq, Show)
+
+$(deriveJSON defaultOptions{fieldLabelModifier = firstLower . dropWhile isLower} ''QuorumCertificate)
+
+-- | A timeout message including the sender's signature.
+data TimeoutMessage = TimeoutMessage
+    { -- | Index of the finalizer signing the message.
+      tmFinalizer :: !FinalizerIndex,
+      -- | Round which timed out.
+      tmRound :: !Round,
+      -- | Current epoch number of the finalizer sending the timeout message.
+      -- This can be different from the epoch of the quorum certificate.
+      tmEpoch :: !Epoch,
+      -- | Highest quorum certificate known to the finalizer at the time of timeout.
+      tmQuorumCertificate :: !QuorumCertificate,
+      -- | Signature on the appropriate timeout signature message.
+      tmSignature :: !TimeoutCertificateSignature,
+      -- | Signature of the finalizer on the timeout message as a whole.
+      tmMessageSignature :: !BlockSignature.Signature
+    }
+    deriving (Eq, Show)
+
+$(deriveJSON defaultOptions{fieldLabelModifier = firstLower . dropWhile isLower} ''TimeoutMessage)
+
+data FinalizerRound = FinalizerRound
+    { -- | The round that was signed off.
+      frRound :: !Round,
+      -- | The finalizers (identified by their 'FinalizerIndex') that
+      -- signed off the in 'round'.
+      frFinalizers :: ![FinalizerIndex]
+    }
+    deriving (Eq, Show)
+
+$(deriveJSON defaultOptions{fieldLabelModifier = firstLower . dropWhile isLower} ''FinalizerRound)
+
+-- | A timeout certificate is the certificate that the
+-- finalization committee issues when a round times out,
+-- thus making it possible for the protocol to proceed to the
+-- next round.
+data TimeoutCertificate = TimeoutCertificate
+    { -- | The round that timed out.
+      tcRound :: !Round,
+      -- | The minimum epoch of which signatures are included
+      -- in the 'aggregate_signature'.
+      tcMinEpoch :: !Epoch,
+      -- | The rounds of which finalizers have their best
+      -- QCs in the 'min_epoch'.
+      tcQcRoundsFirstEpoch :: ![FinalizerRound],
+      -- | The rounds of which finalizers have their best
+      -- QCs in the epoch 'min_epoch' + 1.
+      tcQcRoundsSecondEpoch :: ![FinalizerRound],
+      -- | The aggregated signature by the finalization committee that witnessed
+      -- the 'round' timed out.
+      tcAggregateSignature :: !TimeoutCertificateSignature
+    }
+    deriving (Eq, Show)
+
+$(deriveJSON defaultOptions{fieldLabelModifier = firstLower . dropWhile isLower} ''TimeoutCertificate)
+
+data PersistentRoundStatus = PersistentRoundStatus
+    { -- | The last signed quorum message by the node.
+      prsLastSignedQuorumMessage :: !(Maybe QuorumMessage),
+      -- | The last signed timeout message by the node.
+      prsLastSignedTimeoutMessage :: !(Maybe TimeoutMessage),
+      -- | The last round the node baked in.
+      prsLastBakedRound :: !Round,
+      -- | The latest timeout certificate seen by the node. May be absent if the node has seen a
+      -- quorum certificate for a more recent round.
+      prsLatestTimeout :: !(Maybe TimeoutCertificate)
+    }
+    deriving (Eq, Show)
+
+$(deriveJSON defaultOptions{fieldLabelModifier = firstLower . dropWhile isLower} ''PersistentRoundStatus)
+
+data RoundTimeout = RoundTimeout
+    { -- | The timeout certificate for the round that timed out.
+      rtTimeoutCertificate :: !TimeoutCertificate,
+      -- | The highest quorum certificate known when the round timed out.
+      rtQuorumCertificate :: !QuorumCertificate
+    }
+    deriving (Eq, Show)
+
+$(deriveJSON defaultOptions{fieldLabelModifier = firstLower . dropWhile isLower} ''RoundTimeout)
+
+data FinalizationEntry = FinalizationEntry
+    { -- | The quorum certificate for the finalized block.
+      feFinalizedQC :: !QuorumCertificate,
+      -- | The quorum certificate for the block that finalizes
+      -- the block that 'finalized_qc' points to.
+      feSuccessorQC :: !QuorumCertificate,
+      -- | A proof that the successor block is an immediate
+      -- successor of the finalized block.
+      feSuccessorProof :: !SuccessorProof
+    }
+    deriving (Eq, Show)
+
+$(deriveJSON defaultOptions{fieldLabelModifier = firstLower . dropWhile isLower} ''FinalizationEntry)
+
+data RoundStatus = RoundStatus
+    { -- | The current round from the perspective of the node.
+      -- This should always be higher than the round of the highest certified block.
+      -- If the previous round did not timeout, it should be one more than the round of
+      -- the `highest_certified_block`. Otherwise, it should be one more than the round of
+      -- the `previous_round_timeout`.
+      rsCurrentRound :: !Round,
+      -- | The quorum certificate for the highest certified block.
+      rsHighestCertifiedBlock :: !QuorumCertificate,
+      -- | If the last round timed out, this is the timeout certificate for that round and
+      -- the highest quorum certificate at the time the round timed out.
+      rsPreviousRoundTimeout :: !(Maybe RoundTimeout),
+      -- | Flag indicating whether the node should attempt to bake in the current round.
+      -- This is set to true when the round is advanced, and set to false once the node has
+      -- attempted to bake for the round.
+      rsRoundEligibleToBake :: !Bool,
+      -- | The current epoch. This should either be the same as the epoch of the last finalized
+      -- block (if its timestamp is before the trigger block time) or the next epoch from the last
+      -- finalized block (if its timestamp is at least the trigger block time).
+      rsCurrentEpoch :: !Epoch,
+      -- | If present, an epoch finalization entry for the epoch before `current_epoch`.
+      -- An entry must be present if the current epoch is greater than the epoch of the last
+      -- finalized block.
+      rsLastEpochFinalizationEntry :: !(Maybe FinalizationEntry),
+      -- | The current duration the node will wait before a round times out.
+      rsCurrentTimeout :: !Duration
+    }
+    deriving (Eq, Show)
+
+$(deriveJSON defaultOptions{fieldLabelModifier = firstLower . dropWhile isLower} ''RoundStatus)
+
+data BlockTableSummary = BlockTableSummary
+    { -- | The number of blocks in the dead block cache.
+      btsDeadBlockCacheSize :: !Word64,
+      -- | The blocks that are currently live (not dead and not finalized).
+      btsLiveBlocks :: ![BlockHash]
+    }
+    deriving (Eq, Show)
+
+$(deriveJSON defaultOptions{fieldLabelModifier = firstLower . dropWhile isLower} ''BlockTableSummary)
+
+data RoundExistingBlock = RoundExistingBlock
+    { rebRound :: !Round,
+      rebBaker :: !BakerId,
+      rebBlock :: !BlockHash
+    }
+    deriving (Eq, Show)
+
+$(deriveJSON defaultOptions{fieldLabelModifier = firstLower . dropWhile isLower} ''RoundExistingBlock)
+
+data RoundExistingQC = RoundExistingQC
+    { reqRound :: !Round,
+      reqEpoch :: !Epoch
+    }
+    deriving (Eq, Show)
+
+$(deriveJSON defaultOptions{fieldLabelModifier = firstLower . dropWhile isLower} ''RoundExistingQC)
+
+data FullBakerInfo = FullBakerInfo
+    { -- | The ID of the baker.
+      fbiBakerIdentity :: !BakerId,
+      -- | The election verification key of the baker.
+      fbiElectionVerifyKey :: !VRF.PublicKey,
+      -- | The signature verification key of the baker.
+      fbiSignatureVerifyKey :: !BlockSignature.VerifyKey,
+      -- | The aggregation verification key of the baker.
+      fbiAggregationVerifyKey :: !Bls.PublicKey,
+      -- | The stake of the baker.
+      fbiStake :: !Amount
+    }
+    deriving (Eq, Show)
+
+$(deriveJSON defaultOptions{fieldLabelModifier = firstLower . dropWhile isLower} ''FullBakerInfo)
+
+data BakersAndFinalizers = BakersAndFinalizers
+    { -- | The set of bakers.
+      bafBakers :: ![FullBakerInfo],
+      -- | The IDs of the bakers that are finalizers.
+      -- The order determines the finalizer index.
+      bafFinalizers :: ![BakerId],
+      -- | The total effective stake of the bakers.
+      bafBakerTotalStake :: !Amount,
+      -- | The total effective stake of the finalizers.
+      bafFinalizerTotalStake :: !Amount,
+      -- | The hash of the finalization committee.
+      bafFinalizationCommitteeHash :: !Hash.Hash
+    }
+    deriving (Eq, Show)
+
+$(deriveJSON defaultOptions{fieldLabelModifier = firstLower . dropWhile isLower} ''BakersAndFinalizers)
+
+data EpochBakers = EpochBakers
+    { -- | The bakers and finalizers for the previous epoch.
+      --  If the current epoch is 0, then this is the same as the bakers for the current epoch.
+      ebPreviousEpochBakers :: !BakersAndFinalizers,
+      -- | The bakers and finalizers for the current epoch.
+      --  If this is absent, it should be treated as the same as the bakers for the previous epoch.
+      ebCurrentEpochBakers :: !(Maybe BakersAndFinalizers),
+      -- | The bakers and finalizers for the next epoch.
+      --  If this is absent, it should be treated as the same as the bakers for the current epoch.
+      ebNextEpochBakers :: !(Maybe BakersAndFinalizers),
+      -- | The first epoch of the next payday.
+      ebNextPayday :: !Epoch
+    }
+    deriving (Eq, Show)
+
+$(deriveJSON defaultOptions{fieldLabelModifier = firstLower . dropWhile isLower} ''EpochBakers)
+
+data TimeoutMessages = TimeoutMessages
+    { -- | The first epoch for which timeout messages are present.
+      tmFirstEpoch :: !Epoch,
+      -- | The timeout messages for the first epoch.
+      -- There should always be at least one.
+      tmFirstEpochTimeouts :: ![TimeoutMessage],
+      -- | The timeout messages for @first_epoch + 1@.
+      tmSecondEpochTimeouts :: ![TimeoutMessage]
+    }
+    deriving (Eq, Show)
+
+$(deriveJSON defaultOptions{fieldLabelModifier = firstLower . dropWhile isLower} ''TimeoutMessages)
+
+data ConsensusDetailedStatus = ConsensusDetailedStatus
+    { -- | The hash of the genesis block.
+      cdsGenesisBlock :: !BlockHash,
+      -- | The persisted elements of the round status.
+      cdsPersistentRoundStatus :: !PersistentRoundStatus,
+      -- | The status of the current round.
+      cdsRoundStatus :: !RoundStatus,
+      -- | The number of non-finalized transactions.
+      cdsNonFinalizedTransactionCount :: !Word64,
+      -- | The purge counter for the transaction table.
+      cdsTransactionTablePurgeCounter :: !Int64,
+      -- | Summary of the block table.
+      cdsBlockTable :: !BlockTableSummary,
+      -- | The live blocks organized by height after the last finalized block.
+      cdsBranches :: ![[BlockHash]],
+      -- | Which bakers the node has seen legally-signed blocks with live parents from in non-finalized rounds.
+      cdsRoundExistingBlocks :: ![RoundExistingBlock],
+      -- | Which non-finalized rounds the node has seen quorum certificates for.
+      cdsRoundExistingQCs :: ![RoundExistingQC],
+      -- | The absolute block height of the genesis block of the era.
+      cdsGenesisBlockHeight :: !AbsoluteBlockHeight,
+      -- | The hash of the last finalized block.
+      cdsLastFinalizedBlock :: !BlockHash,
+      -- | The height of the last finalized block.
+      cdsLastFinalizedBlockHeight :: !BlockHeight,
+      -- | Unless the last finalized block is the genesis block, this should be a finalization entry for the last finalized block.
+      cdsLatestFinalizationEntry :: !(Maybe FinalizationEntry),
+      -- | The bakers and finalizers for the previous, current and next epoch, relative to the last finalized block.
+      cdsEpochBakers :: !EpochBakers,
+      -- | The timeout messages collected by the node for the current round.
+      cdsTimeoutMessages :: !(Maybe TimeoutMessages),
+      -- | If a protocol update has occurred, this is the hash of the terminal block.
+      cdsTerminalBlock :: !(Maybe BlockHash)
+    }
+    deriving (Eq, Show)
+
+$(deriveJSON defaultOptions{fieldLabelModifier = firstLower . dropWhile isLower} ''ConsensusDetailedStatus)


### PR DESCRIPTION
## Purpose

Support the `GetConsensusDetailedStatus` query.

## Changes

- Add new command `consensus detailed-status`.
- Add new raw command `raw GetConsensusDetailedStatus`.

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [X] (If necessary) I have updated the CHANGELOG.
