### PR TITLE
Support new GRPC endpoints

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -2,12 +2,19 @@
 
 ## Unreleased
 
+Note: due to API changes, this release may not work correctly with node versions prior to 8.
+
 - Support node version 8 and protocol version 8.
 - Support for suspend/resume in validator update transactions.
 - Add command `consensus detailed-status` for getting detailed consensus status (from protocol
   version 6).
 - Add `raw GetConsensusDetailedStatus` that presents the detailed consensus status as JSON.
 - Update GHC version to 9.6.6 (lts-22.39).
+- Add raw commands `GetScheduledReleaseAccounts`, `GetCooldownAccounts`,
+  `GetPreCooldownAccounts` and `GetPrePreCooldownAccounts` for querying
+  accounts with scheduled releases, cooldowns, pre-cooldowns and pre-pre-cooldowns.
+- Raw commands `GetBlockTransactionEvents` and `GetTransactionStatus` include the `parameter`
+  for `ContractInitialized` events.
 
 ## 7.0.1
 

--- a/concordium-client.cabal
+++ b/concordium-client.cabal
@@ -1,11 +1,11 @@
 cabal-version: 1.24
 
--- This file has been generated from package.yaml by hpack version 0.36.0.
+-- This file has been generated from package.yaml by hpack version 0.37.0.
 --
 -- see: https://github.com/sol/hpack
 
 name:           concordium-client
-version:        7.0.1
+version:        7.0.2
 description:    Please see the README on GitHub at <https://github.com/Concordium/concordium-client#readme>
 homepage:       https://github.com/Concordium/concordium-client#readme
 bug-reports:    https://github.com/Concordium/concordium-client/issues

--- a/src/Concordium/Client/LegacyCommands.hs
+++ b/src/Concordium/Client/LegacyCommands.hs
@@ -169,6 +169,18 @@ data LegacyCmd
         {legacyEpoch :: !EpochSpecifier}
     | GetFirstBlockEpoch
         {legacyEpoch :: !EpochSpecifier}
+    | -- | Get the list of accounts with scheduled releases.
+      GetScheduledReleaseAccounts
+        {legacyBlockHash :: !(Maybe Text)}
+    | -- | Get the list of accounts with stake in cooldown.
+      GetCooldownAccounts
+        {legacyBlockHash :: !(Maybe Text)}
+    | -- | Get the list of accounts with stake in pre-cooldown.
+      GetPreCooldownAccounts
+        {legacyBlockHash :: !(Maybe Text)}
+    | -- | Get the list of accounts with stake in pre-pre-cooldown.
+      GetPrePreCooldownAccounts
+        {legacyBlockHash :: !(Maybe Text)}
     deriving (Show)
 
 legacyProgramOptions :: Parser LegacyCmd
@@ -213,6 +225,10 @@ legacyProgramOptions =
             <> getAnonymityRevokersCommand
             <> getCryptographicParametersCommand
             <> getNextUpdateSequenceNumbersCommand
+            <> getScheduledReleaseAccountsCommand
+            <> getCooldownAccountsCommand
+            <> getPreCooldownAccountsCommand
+            <> getPrePreCooldownAccountsCommand
             <> getBakersRewardPeriodCommand "GetValidatorsRewardPeriod"
             <> getBlockCertificatesCommand
             <> getBakerEarliestWinTimeCommand "GetValidatorEarliestWinTime"
@@ -424,6 +440,50 @@ getNextUpdateSequenceNumbersCommand =
                 <$> optional (strArgument (metavar "BLOCK-HASH" <> help "Hash of the block to query (default: Query the best block)"))
             )
             (progDesc "Query the gRPC server for the next update sequence numbers for all update queues.")
+        )
+
+getScheduledReleaseAccountsCommand :: Mod CommandFields LegacyCmd
+getScheduledReleaseAccountsCommand =
+    command
+        "GetScheduledReleaseAccounts"
+        ( info
+            ( GetScheduledReleaseAccounts
+                <$> optional (strArgument (metavar "BLOCK-HASH" <> help "Hash of the block to query (default: Query the best block)"))
+            )
+            (progDesc "Query the gRPC server for all accounts that have scheduled releases, with the timestamp of the first pending scheduled release for that account.")
+        )
+
+getCooldownAccountsCommand :: Mod CommandFields LegacyCmd
+getCooldownAccountsCommand =
+    command
+        "GetCooldownAccounts"
+        ( info
+            ( GetCooldownAccounts
+                <$> optional (strArgument (metavar "BLOCK-HASH" <> help "Hash of the block to query (default: Query the best block)"))
+            )
+            (progDesc "Query the gRPC server for all accounts that have stake in cooldown, with the timestamp of the first pending cooldown expiry for each account.")
+        )
+
+getPreCooldownAccountsCommand :: Mod CommandFields LegacyCmd
+getPreCooldownAccountsCommand =
+    command
+        "GetPreCooldownAccounts"
+        ( info
+            ( GetPreCooldownAccounts
+                <$> optional (strArgument (metavar "BLOCK-HASH" <> help "Hash of the block to query (default: Query the best block)"))
+            )
+            (progDesc "Query the gRPC server for all accounts that have stake in pre-cooldown.")
+        )
+
+getPrePreCooldownAccountsCommand :: Mod CommandFields LegacyCmd
+getPrePreCooldownAccountsCommand =
+    command
+        "GetPrePreCooldownAccounts"
+        ( info
+            ( GetPrePreCooldownAccounts
+                <$> optional (strArgument (metavar "BLOCK-HASH" <> help "Hash of the block to query (default: Query the best block)"))
+            )
+            (progDesc "Query the gRPC server for all accounts that have stake in pre-pre-cooldown.")
         )
 
 getBakersRewardPeriodCommand :: String -> Mod CommandFields LegacyCmd

--- a/src/Concordium/Client/Types/TransactionStatus.hs
+++ b/src/Concordium/Client/Types/TransactionStatus.hs
@@ -19,7 +19,7 @@ $(deriveJSON defaultOptions{constructorTagModifier = firstLower} ''TransactionSt
 
 type TransactionBlockResults' a = Map.Map BlockHash (TransactionSummary' a)
 
-type TransactionBlockResults = TransactionBlockResults' ValidResult
+type TransactionBlockResults = TransactionBlockResults' SupplementedValidResult
 
 data TransactionStatusResult' a = TransactionStatusResult
     { tsrState :: !TransactionState,
@@ -27,13 +27,13 @@ data TransactionStatusResult' a = TransactionStatusResult
     }
     deriving (Eq, Show)
 
-type TransactionStatusResult = TransactionStatusResult' ValidResult
+type TransactionStatusResult = TransactionStatusResult' SupplementedValidResult
 
 -- | Convert a @TransactionStatus@ instance into a @TransactionStatusResult@ instance.
 --  Returns a @Left@ wrapping an error message if either the transaction summary contained in the
 --  input is @Nothing@, or the input is of variant @Committed@ or @Finalized@. Returns a @Right@
 --  wrapping the corresponding @TransactionStatusResult@ otherwise.
-transactionStatusToTransactionStatusResult :: Queries.TransactionStatus -> Either String TransactionStatusResult
+transactionStatusToTransactionStatusResult :: Queries.SupplementedTransactionStatus -> Either String TransactionStatusResult
 transactionStatusToTransactionStatusResult tStatus = do
     (tsrState, tsrResults) <- do
         case tStatus of

--- a/test/SimpleClientTests/TransactionSpec.hs
+++ b/test/SimpleClientTests/TransactionSpec.hs
@@ -83,13 +83,13 @@ exampleBlockHash3 = read "941c24374cd077de2120fb58732306c3115a08bb7b7cda120a04fe
 exampleBlockHash4 :: Types.BlockHash
 exampleBlockHash4 = read "be880f81dfbcc0a049c3defe483327d0a2a3002a186a06d34bcd93a9be7f9994"
 
-exampleEvent :: Types.Event
+exampleEvent :: Types.SupplementedEvent
 exampleEvent = Types.Transferred (Types.AddressAccount exampleAccountAddr1) 10 (Types.AddressAccount exampleAccountAddr2)
 
 exampleRejectReason :: Types.RejectReason
 exampleRejectReason = Types.AmountTooLarge (Types.AddressAccount exampleAccountAddr1) 11
 
-outcomeSuccess1a :: Types.TransactionSummary
+outcomeSuccess1a :: Types.SupplementedTransactionSummary
 outcomeSuccess1a =
     Types.TransactionSummary
         { Types.tsSender = Just exampleAccountAddr1,
@@ -101,7 +101,7 @@ outcomeSuccess1a =
           Types.tsIndex = Types.TransactionIndex 0
         }
 
-outcomeSuccess1b :: Types.TransactionSummary
+outcomeSuccess1b :: Types.SupplementedTransactionSummary
 outcomeSuccess1b =
     Types.TransactionSummary
         { Types.tsSender = Just exampleAccountAddr1,
@@ -113,7 +113,7 @@ outcomeSuccess1b =
           Types.tsIndex = 0
         }
 
-outcomeSuccess2 :: Types.TransactionSummary
+outcomeSuccess2 :: Types.SupplementedTransactionSummary
 outcomeSuccess2 =
     Types.TransactionSummary
         { Types.tsSender = Just exampleAccountAddr1,
@@ -125,7 +125,7 @@ outcomeSuccess2 =
           Types.tsIndex = 0
         }
 
-outcomeFailure :: Types.TransactionSummary
+outcomeFailure :: Types.SupplementedTransactionSummary
 outcomeFailure =
     Types.TransactionSummary
         { Types.tsSender = Just exampleAccountAddr1,


### PR DESCRIPTION
## Purpose

Closes #331 
Depends on: https://github.com/Concordium/concordium-base/pull/578

This adds support for the new GRPC queries `GetScheduledReleaseAccounts`, `GetCooldownAccounts`, `GetPreCooldownAccounts`, and `GetPrePreCooldownAccounts` as raw commands. Additionally, it supports the `parameter` field in `ContractInitialized` transaction events.

## Changes

- Use `SupplementedEvent`, `SupplementedTransactionStatus`, `SupplementedTransactionSummary` and `SupplementedValidResult` in place of the non-supplemented versions.
- Decode the `parameter` field in `ContractInitialized` events.
- Add gRPC wrappers and raw commands for:
  -  `GetScheduledReleaseAccounts`
  - `GetCooldownAccounts`
  - `GetPreCooldownAccounts`
  - `GetPrePreCooldownAccounts`

## Checklist

- [X] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [X] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [X] (If necessary) I have updated the CHANGELOG.
