### PR TITLE
Support for chain parameters v3

### DIFF
--- a/src/Concordium/Client/Output.hs
+++ b/src/Concordium/Client/Output.hs
@@ -883,10 +883,10 @@ showEvent verbose ciM = \case
     Types.Resumed cAddr invokeSucceeded ->
         let invokeMsg :: Text = if invokeSucceeded then "succeeded" else "failed"
         in  verboseOrNothing [i|resumed '#{cAddr}' after an interruption that #{invokeMsg}.|]
-    Types.BakerSuspended bID ->
-        verboseOrNothing $ printf "baker %s suspended" (show bID)
-    Types.BakerResumed bID ->
-        verboseOrNothing $ printf "baker %s resumed" (show bID)
+    Types.BakerSuspended bID acc ->
+        verboseOrNothing $ printf "baker %s with account %s suspended" (show bID) (show acc)
+    Types.BakerResumed bID acc ->
+        verboseOrNothing $ printf "baker %s with account %s resumed" (show bID) (show acc)
   where
     verboseOrNothing :: String -> Maybe String
     verboseOrNothing msg = if verbose then Just msg else Nothing
@@ -1237,6 +1237,7 @@ printChainParametersV3 ChainParameters{..} = do
     printRewardAndTimeParameters _cpRewardParameters _cpTimeParameters
     printConsensusParametersV1 _cpConsensusParameters
     mapM_ printFinalizationCommitteeParameters _cpFinalizationCommitteeParameters
+    mapM_ printValidatorScoreParameters _cpValidatorScoreParameters
     tell
         [ "",
           [i|\# Other parameters: |],
@@ -1337,6 +1338,14 @@ printFinalizationCommitteeParameters fcp =
           [i|  + minimum finalizers: #{show (fcp ^. fcpMinFinalizers)}|],
           [i|  + maximum finalizers: #{show (fcp ^. fcpMaxFinalizers)}|],
           [i|  + finalizer relative stake threshold: #{show (fcp ^. fcpFinalizerRelativeStakeThreshold)}|]
+        ]
+
+printValidatorScoreParameters :: ValidatorScoreParameters -> Printer
+printValidatorScoreParameters vsp =
+    tell
+        [ "",
+          [i|\# Validator score parameters:|],
+          [i|  + maximum missed rounds: #{show (vsp ^. vspMaxMissedRounds)}|]
         ]
 
 -- | Returns a string representation of the given 'InclusiveRange'.


### PR DESCRIPTION
## Purpose

This adds support for chain parameters v3 containing the `ValidatorScoreParameters`.

## Changes

- update of concordium-base dependency
- `fromProto` implementations for `ValidatorScoreParameters`

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [x] (If necessary) I have updated the CHANGELOG.

## CLA acceptance

_Remove if not applicable.

By submitting the contribution I accept the terms and conditions of the
Contributor License Agreement v1.0
- link: https://developers.concordium.com/CLAs/Contributor-License-Agreement-v1.0.pdf

- [x] I accept the above linked CLA.
