### PR TITLE
fix: remove bakerId field from generated validator keys

### DIFF
--- a/src/Concordium/Client/Cli.hs
+++ b/src/Concordium/Client/Cli.hs
@@ -270,7 +270,7 @@ data BakerCredentials = BakerCredentials
     }
 
 instance AE.ToJSON BakerCredentials where
-    toJSON BakerCredentials{..} = object (("bakerId" .= bcIdentity) : ("validatorId" .= bcIdentity) : bakerKeysToPairs bcKeys)
+    toJSON BakerCredentials{..} = object (("validatorId" .= bcIdentity) : bakerKeysToPairs bcKeys)
 
 instance AE.FromJSON BakerKeys where
     parseJSON = withObject "Baker keys" $ \v -> do
@@ -300,7 +300,7 @@ bakerKeysToPairs v =
       "signatureSignKey" .= bkSigSignKey v,
       "signatureVerifyKey" .= bkSigVerifyKey v
     ]
-        ++ concat [["bakerId" .= bid, "validatorId" .= bid] | bid <- maybeToList (bkBakerId v)]
+        ++ concat [["validatorId" .= bid] | bid <- maybeToList (bkBakerId v)]
 
 instance AE.ToJSON BakerKeys where
     toJSON = object . bakerKeysToPairs
@@ -312,7 +312,7 @@ bakerPublicKeysToPairs v =
       "electionVerifyKey" .= bkElectionVerifyKey v,
       "signatureVerifyKey" .= bkSigVerifyKey v
     ]
-        ++ concat [["bakerId" .= bid, "validatorId" .= bid] | bid <- maybeToList (bkBakerId v)]
+        ++ concat [["validatorId" .= bid] | bid <- maybeToList (bkBakerId v)]
 
 -- | Hardcoded network ID.
 defaultNetId :: Int


### PR DESCRIPTION
Changes the `ToJSON` instances to only print 'validatorId' instead both 'validatorId' and 'bakerId'. The `FromJSON` instance is unchanged


## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [x] (If necessary) I have updated the CHANGELOG.

## CLA acceptance

_Remove if not applicable.

By submitting the contribution I accept the terms and conditions of the
Contributor License Agreement v1.0
- link: https://developers.concordium.com/CLAs/Contributor-License-Agreement-v1.0.pdf

- [x] I accept the above linked CLA.
