### PR TITLE
Show initialization parameter in `transaction status` command

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -2,7 +2,8 @@
 
 ## Unreleased
 
-- The `transaction status` command includes the `parameter` for `ContractInitialized` events.
+- The `transaction status` command output includes the `parameter` for
+  `ContractInitialized` events.
 
 ## 8.0.0
 

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- The `transaction status` command includes the `parameter` for `ContractInitialized` events.
+
 ## 8.0.0
 
 Note: due to API changes, this release may not work correctly with node versions prior to 8.

--- a/src/Concordium/Client/Output.hs
+++ b/src/Concordium/Client/Output.hs
@@ -798,8 +798,9 @@ showEvent verbose ciM = \case
         verboseOrNothing $ printf "module '%s' deployed" (show ref)
     Types.ContractInitialized{..} ->
         verboseOrNothing $
-            [i|initialized contract '#{ecAddress}' using init function '#{ecInitName}' from module '#{ecRef}' |]
-                <> [i|with #{showCcd ecAmount}\n#{showLoggedEvents ecEvents}|]
+            [i|initialized contract '#{ecAddress}' using init function #{ecInitName} from module '#{ecRef}' |]
+                <> [i|with #{showCcd ecAmount} #{foldMap (\p -> "and " ++ showInitParameter p) ecParameter}.\n|]
+                <> [i|#{showLoggedEvents ecEvents}\n|]
     Types.Updated{..} ->
         verboseOrNothing $
             [i|sent message to function '#{euReceiveName}' with #{showParameter euReceiveName euMessage} and #{showCcd euAmount} |]
@@ -958,6 +959,11 @@ showEvent verbose ciM = \case
         rSchemaM = case ciM of
             Nothing -> Nothing
             Just ci -> CI.getParameterSchema ci rName
+
+    -- Show a initialization parameter
+    -- TODO (drsk) pretty print  according to a schema, if present.
+    showInitParameter :: Wasm.Parameter -> String
+    showInitParameter pa = [i|parameter (raw): '#{pa}'|]
 
 -- | Return string representation of reject reason.
 --  If verbose is true, the string includes the details from the fields of the reason.

--- a/src/Concordium/Client/Output.hs
+++ b/src/Concordium/Client/Output.hs
@@ -960,10 +960,14 @@ showEvent verbose ciM = \case
             Nothing -> Nothing
             Just ci -> CI.getParameterSchema ci rName
 
-    -- Show a initialization parameter
-    -- TODO (drsk) pretty print  according to a schema, if present.
+    -- Show an initialization parameter
     showInitParameter :: Wasm.Parameter -> String
-    showInitParameter pa = [i|parameter (raw): '#{pa}'|]
+    showInitParameter pa@(Wasm.Parameter bs) = case toJSONString iniSchemaM bs of
+        Nothing -> [i|parameter (raw): '#{pa}'|]
+        Just json -> [i|parameter:\n#{indentBy 4 $ "'" <> json <> "'"}|]
+      where
+        -- If contract info is present, try go get the receive name schema.
+        iniSchemaM = ciM >>= CI.getInitParameterSchema
 
 -- | Return string representation of reject reason.
 --  If verbose is true, the string includes the details from the fields of the reason.

--- a/src/Concordium/Client/Types/Contract/Info.hs
+++ b/src/Concordium/Client/Types/Contract/Info.hs
@@ -338,8 +338,7 @@ instance AE.FromJSON ContractInfo where
     parseJSON = AE.withObject "Info" $ \v -> do
         ciAmount <- v .: "amount"
         ciOwner <- v .: "owner"
-        ciInitName <- v .: "name"
-        let ciName = contractNameFromInitName ciInitName
+        ciName <- contractNameFromInitName <$> v .: "name"
         ciSourceModule <- v .: "sourceModule"
         methods <- fmap methodNameFromReceiveName <$> v .: "methods"
         (v AE..:! "version" AE..!= (0 :: Word32)) >>= \case

--- a/src/Concordium/Client/Types/Contract/Info.hs
+++ b/src/Concordium/Client/Types/Contract/Info.hs
@@ -6,6 +6,7 @@ module Concordium.Client.Types.Contract.Info (
     getContractName,
     getEventSchema,
     getParameterSchema,
+    getInitParameterSchema,
     hasFallbackReceiveSupport,
     hasReceiveMethod,
     methodNameFromReceiveName,
@@ -66,51 +67,52 @@ import Data.Word (Word32)
 --   - The version of module schema and contract info does not match.
 addSchemaData :: (MonadIO m) => ContractInfo -> CS.ModuleSchema -> ClientMonad m (Maybe ContractInfo)
 addSchemaData cInfo@ContractInfoV1{..} moduleSchema =
-    case moduleSchema of
-        CS.ModuleSchemaV0 _ -> logFatal ["Internal error: Cannot use ModuleSchemaV0 with ContractInfoV1."] -- Should never happen.
-        CS.ModuleSchemaV1{..} ->
-            case ciMethods of
-                NoSchemaV1{..} -> case Map.lookup ciName ms1ContractSchemas of
-                    Nothing -> do
-                        logWarn
-                            [ [i|A schema for the contract '#{ciName}' does not exist in the schema provided.|],
-                              "Showing the contract without information from the schema."
-                            ]
-                        return Nothing
-                    Just contrSchema ->
-                        let ws1Methods = map (addFuncSchemaToMethodV1 contrSchema) ns1Methods
-                            withSchema = WithSchemaV1{..}
-                        in  return $ Just (cInfo{ciMethods = withSchema})
-                _ -> logFatal ["Internal error: Contract info has already been decoded."] -- Matches WithSchema1 / WithSchema2. Should never happen.
-        CS.ModuleSchemaV2{..} ->
-            case ciMethods of
-                NoSchemaV1{..} -> case Map.lookup ciName ms2ContractSchemas of
-                    Nothing -> do
-                        logWarn
-                            [ [i|A schema for the contract '#{ciName}' does not exist in the schema provided.|],
-                              "Showing the contract without information from the schema."
-                            ]
-                        return Nothing
-                    Just contrSchema ->
-                        let ws2Methods = map (addFuncSchemaToMethodV2 contrSchema) ns1Methods
-                            withSchema = WithSchemaV2{..}
-                        in  return $ Just (cInfo{ciMethods = withSchema})
-                _ -> logFatal ["Internal error: Contract info has already been decoded."] -- Matches WithSchema1 / WithSchema2. Should never happen.
-        CS.ModuleSchemaV3{..} ->
-            case ciMethods of
-                NoSchemaV1{..} -> case Map.lookup ciName ms3ContractSchemas of
-                    Nothing -> do
-                        logWarn
-                            [ [i|A schema for the contract '#{ciName}' does not exist in the schema provided.|],
-                              "Showing the contract without information from the schema."
-                            ]
-                        return Nothing
-                    Just contrSchema ->
-                        let ws3Methods = map (addFuncSchemaToMethodV3 contrSchema) ns1Methods
-                            ws3Event = CS.cs3EventSchema contrSchema
-                            withSchema = WithSchemaV3{..}
-                        in  return $ Just (cInfo{ciMethods = withSchema})
-                _ -> logFatal ["Internal error: Contract info has already been decoded."] -- Matches WithSchema*. Should never happen.
+    let ciInitParamM = CS.lookupParameterSchema moduleSchema (CS.InitFuncName ciName)
+    in  case moduleSchema of
+            CS.ModuleSchemaV0 _ -> logFatal ["Internal error: Cannot use ModuleSchemaV0 with ContractInfoV1."] -- Should never happen.
+            CS.ModuleSchemaV1{..} ->
+                case ciMethods of
+                    NoSchemaV1{..} -> case Map.lookup ciName ms1ContractSchemas of
+                        Nothing -> do
+                            logWarn
+                                [ [i|A schema for the contract '#{ciName}' does not exist in the schema provided.|],
+                                  "Showing the contract without information from the schema."
+                                ]
+                            return Nothing
+                        Just contrSchema ->
+                            let ws1Methods = map (addFuncSchemaToMethodV1 contrSchema) ns1Methods
+                                withSchema = WithSchemaV1{..}
+                            in  return $ Just (cInfo{ciMethods = withSchema, ciInitParamSchemaM = ciInitParamM})
+                    _ -> logFatal ["Internal error: Contract info has already been decoded."] -- Matches WithSchema1 / WithSchema2. Should never happen.
+            CS.ModuleSchemaV2{..} ->
+                case ciMethods of
+                    NoSchemaV1{..} -> case Map.lookup ciName ms2ContractSchemas of
+                        Nothing -> do
+                            logWarn
+                                [ [i|A schema for the contract '#{ciName}' does not exist in the schema provided.|],
+                                  "Showing the contract without information from the schema."
+                                ]
+                            return Nothing
+                        Just contrSchema ->
+                            let ws2Methods = map (addFuncSchemaToMethodV2 contrSchema) ns1Methods
+                                withSchema = WithSchemaV2{..}
+                            in  return $ Just (cInfo{ciMethods = withSchema, ciInitParamSchemaM = ciInitParamM})
+                    _ -> logFatal ["Internal error: Contract info has already been decoded."] -- Matches WithSchema1 / WithSchema2. Should never happen.
+            CS.ModuleSchemaV3{..} ->
+                case ciMethods of
+                    NoSchemaV1{..} -> case Map.lookup ciName ms3ContractSchemas of
+                        Nothing -> do
+                            logWarn
+                                [ [i|A schema for the contract '#{ciName}' does not exist in the schema provided.|],
+                                  "Showing the contract without information from the schema."
+                                ]
+                            return Nothing
+                        Just contrSchema ->
+                            let ws3Methods = map (addFuncSchemaToMethodV3 contrSchema) ns1Methods
+                                ws3Event = CS.cs3EventSchema contrSchema
+                                withSchema = WithSchemaV3{..}
+                            in  return $ Just (cInfo{ciMethods = withSchema, ciInitParamSchemaM = ciInitParamM})
+                    _ -> logFatal ["Internal error: Contract info has already been decoded."] -- Matches WithSchema*. Should never happen.
   where
     addFuncSchemaToMethodV1 :: CS.ContractSchemaV1 -> Text -> (Text, Maybe CS.FunctionSchemaV1)
     addFuncSchemaToMethodV1 contrSchema rcvName =
@@ -231,6 +233,11 @@ getParameterSchema ci rcvName = case ci of
         Nothing -> Nothing
         Just (_, v) -> v
 
+getInitParameterSchema :: ContractInfo -> Maybe CS.SchemaType
+getInitParameterSchema ci = case ci of
+    ContractInfoV0{} -> Nothing
+    ContractInfoV1{..} -> ciInitParamSchemaM
+
 -- | This is returned by the node and specified in Concordium.Getters (from prototype repo).
 --  Must stay in sync.
 data ContractInfo
@@ -259,7 +266,9 @@ data ContractInfo
           -- | The corresponding source module.
           ciSourceModule :: !T.ModuleRef,
           -- | The methods of the contract.
-          ciMethods :: !Methods
+          ciMethods :: !Methods,
+          -- | The initialization parameter schema, if present.
+          ciInitParamSchemaM :: !(Maybe CS.SchemaType)
         }
     deriving (Eq, Show)
 
@@ -321,6 +330,7 @@ instanceInfoToContractInfo iInfo =
                 ciSourceModule = iiSourceModule
                 methods = methodNameFromReceiveName <$> Set.toList iiMethods
                 ciMethods = NoSchemaV1{ns1Methods = methods}
+                ciInitParamSchemaM = Nothing
             in
                 ContractInfoV1{..}
 
@@ -328,7 +338,8 @@ instance AE.FromJSON ContractInfo where
     parseJSON = AE.withObject "Info" $ \v -> do
         ciAmount <- v .: "amount"
         ciOwner <- v .: "owner"
-        ciName <- contractNameFromInitName <$> v .: "name"
+        ciInitName <- v .: "name"
+        let ciName = contractNameFromInitName ciInitName
         ciSourceModule <- v .: "sourceModule"
         methods <- fmap methodNameFromReceiveName <$> v .: "methods"
         (v AE..:! "version" AE..!= (0 :: Word32)) >>= \case
@@ -347,6 +358,7 @@ instance AE.FromJSON ContractInfo where
                 return ContractInfoV0{..}
             1 ->
                 let ciMethods = NoSchemaV1{ns1Methods = methods}
+                    ciInitParamSchemaM = Nothing
                 in  return ContractInfoV1{..}
             n -> fail [i|Unsupported contract version #{n}.|]
 


### PR DESCRIPTION
## Purpose

Show the initialization parameter pretty printed according to schema for the `transaction status` command of the client. Fixes #291.

## Changes

- Pretty printer extended
- `ContractInfo` is extended with the optional schema for the initialization parameter
- `addSchemaData` supplements the `ContractInfo` with the schema for the initialization parameter.

The output with this change and a schema present:
```
Transaction is finalized into block 89baffd8736126301e846ab8696a47df29eeaea8f1623bdf45d99993443fbbbc with status "success" and cost 0.281554 CCD (794 NRG).
initialized contract '<5073, 0>' using init function "init_counter" from module '0ce173f529562efae7dcf20bf1d6bd521823ee689961a01b6e1760cdacd264a1' with 0.000000 CCD and parameter:
    '{
        "num": 12
    }'.
No contract events were emitted.
```

Without schema:
```
Transaction is finalized into block 74ec5c78c5b3d5dcb53259c14c108bfed950cf0de1838f840efc02a5aa034bb1 with status "success" and cost 0.249657 CCD (724 NRG).
initialized contract '<5066, 0>' using init function "init_counter" from module '1e4a1eff5e79ad952a908e6a9c932c5bb51363a706e27cd7d12a6cd945dcc037' with 0.000000 CCD and parameter (raw): '2c'.
No contract events were emitted.
```

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [x] (If necessary) I have updated the CHANGELOG.

## CLA acceptance



By submitting the contribution I accept the terms and conditions of the
Contributor License Agreement v1.0
- link: https://developers.concordium.com/CLAs/Contributor-License-Agreement-v1.0.pdf

- [ ] I accept the above linked CLA.
