### PR TITLE
Add tokens to account info queries (COR-1357)

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Subcommand `account show` now displays protocol level tokens info.
+- Subcommand `raw GetAccountInfo` now displays protocol level tokens info.
 - Add `transaction transfer-plt` command to transfer protocol level tokens from one account to another.
 - Add `raw GetTokenList` command to display the list of protocol level tokens.
 - Subcommand `raw GetNextUpdateSequenceNumbers` now displays the next update sequence number for protocol level tokens chain updates.

--- a/src/Concordium/Client/Output.hs
+++ b/src/Concordium/Client/Output.hs
@@ -203,8 +203,7 @@ prettyPrintTokens = map formatToken
     formatToken (Types.Token tid (Types.TokenAccountState (Types.TokenAmount digits decs) inAllowList inDenyList)) =
         let amount = fromIntegral digits / (10 ^ decs :: Double)
         in  unlines
-                [ indent ++ "Token ID:            " ++ show tid,
-                  indent ++ "Balance:             " ++ printf ("%." ++ show decs ++ "f") amount,
+                [ indent ++ "Balance:             " ++ printf ("%." ++ show decs ++ "f ") amount ++ show tid,
                   indent ++ "In Allow List:       " ++ show inAllowList,
                   indent ++ "In Deny List:        " ++ show inDenyList
                 ]

--- a/src/Concordium/Client/Output.hs
+++ b/src/Concordium/Client/Output.hs
@@ -218,10 +218,12 @@ printAccountInfo addr a verbose showEncrypted mEncKey = do
         ( [ [i|Local names:            #{showNameList $ naNames addr}|],
             [i|Address:                #{naAddr addr}|],
             [i|Balance:                #{balance}|],
-            [i| - At disposal:         #{rjustCcd (Types.aiAccountAvailableAmount a)}|],
-            [i|Tokens:|],
-            [i|#{unlines tokens}|]
+            [i| - At disposal:         #{rjustCcd (Types.aiAccountAvailableAmount a)}|]
           ]
+            ++ ( if not (null tokens)
+                    then [[i|Tokens:|], [i|#{unlines tokens}|]]
+                    else []
+               )
             ++ case Types.releaseTotal $ Types.aiAccountReleaseSchedule a of
                 0 -> []
                 tot ->

--- a/src/Concordium/Client/Runner.hs
+++ b/src/Concordium/Client/Runner.hs
@@ -1234,7 +1234,7 @@ getAccountInfoWithBHOrDie sender bhInput = do
 
 -- | Query the chain for the given account, returning the account info.
 --  Die printing an error message containing the nature of the error if such occurred.
-getAccountInfoOrDie :: (MonadIO m) => Types.AccountIdentifier -> BlockHashInput -> ClientMonad m (Types.AccountInfo)
+getAccountInfoOrDie :: (MonadIO m) => Types.AccountIdentifier -> BlockHashInput -> ClientMonad m Types.AccountInfo
 getAccountInfoOrDie sender bhInput = fst <$> getAccountInfoWithBHOrDie sender bhInput
 
 -- | Query the chain for the given pool.


### PR DESCRIPTION
## Purpose

```
stack run concordium-client -- raw GetAccountInfo 2 --grpc-port 15001 --grpc-ip 0.0.0.0

stack run concordium-client -- account show 2 --grpc-port 15001 --grpc-ip 0.0.0.0
```

Related to:
https://github.com/Concordium/concordium-base/pull/632

## Changes

- Subcommand `account show` now displays protocol level tokens info.
- Subcommand `raw GetAccountInfo` now displays protocol level tokens info.


![Screenshot from 2025-05-07 15-16-16](https://github.com/user-attachments/assets/9a7383a2-28ca-4812-ad56-3beebf9f69af)

![Screenshot from 2025-05-07 15-15-55](https://github.com/user-attachments/assets/62c90871-df8a-4372-92cd-2aae78b8c7d8)

