### PR TITLE
Address feedback

### DIFF
--- a/src/Concordium/Client/GRPC2.hs
+++ b/src/Concordium/Client/GRPC2.hs
@@ -728,8 +728,8 @@ instance FromProto Proto.AccountInfo'Token where
 instance FromProto ProtoPLT.TokenAccountState where
     type Output ProtoPLT.TokenAccountState = Tokens.TokenAccountState
     fromProto tokenAccountState = do
-        let memberAllowList = tokenAccountState ^. ProtoFieldsPLT.memberAllowList
-        let memberDenyList = tokenAccountState ^. ProtoFieldsPLT.memberDenyList
+        let memberAllowList = tokenAccountState ^. ProtoFieldsPLT.maybe'memberAllowList
+        let memberDenyList = tokenAccountState ^. ProtoFieldsPLT.maybe'memberDenyList
         balance <- fromProto $ tokenAccountState ^. ProtoFieldsPLT.balance
         return Tokens.TokenAccountState{..}
 

--- a/src/Concordium/Client/LegacyCommands.hs
+++ b/src/Concordium/Client/LegacyCommands.hs
@@ -467,7 +467,7 @@ getTokenInfoCommand =
         "GetTokenInfo"
         ( info
             ( GetTokenInfo
-                <$> strOption (long "tokenId" <> metavar "TOKEN_ID" <> help "Token id (Symbol) of the token.")
+                <$> strArgument (metavar "TOKEN_ID" <> help "Token id (Symbol) of the token.")
                 <*> optional (strArgument (metavar "BLOCK-HASH" <> help "Hash of the block to query (default: Query the best block)"))
             )
             (progDesc "Query the gRPC server for the info of a protocol level token.")

--- a/src/Concordium/Client/Runner.hs
+++ b/src/Concordium/Client/Runner.hs
@@ -905,7 +905,7 @@ processTransactionCmd action baseCfgDir verbose backend =
 
             receiverAddress <- getAccountAddressArg (bcAccountNameMap baseCfg) receiver
             let receiverAccount = naAddr receiverAddress
-            let tokenReceiver = CBOR.accountTokenReceiver receiverAccount
+            let tokenReceiver = CBOR.accountTokenHolder receiverAccount
 
             withClient backend $ do
                 cs <- getResponseValueOrDie =<< getConsensusInfo


### PR DESCRIPTION
## Purpose

https://concordium.slack.com/archives/C03DRCC9GR1/p1746799720102459

## Changes
- Align `GetTokenInfo --tokenId ETH99` command with the rest of the `raw commands` by removing the explicit option `GetTokenInfo ETH99`

Update submodule link to:
- Improve display of `tokenId` without `"`
- Fix typo `tokenId` should be `tokenModuleReference`.
