### PR TITLE
Add transaction modify list command (COR-1370)

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -2,10 +2,10 @@
 
 ## Unreleased
 
-- Add `transaction plt add-to-allowList` to add an account to the allow list by the governance account.
-- Add `transaction plt add-to-denyList` to add an account to the deny list by the governance account.
-- Add `transaction plt remove-from-allowList` to remove an account from the allow list by the governance account.
-- Add `transaction plt remove-from-denyList` to remove an account from the deny list by the governance account.
+- Add `transaction plt add-to-allow-list` to add an account to the allow list by the governance account.
+- Add `transaction plt add-to-deny-list` to add an account to the deny list by the governance account.
+- Add `transaction plt remove-from-allow-list` to remove an account from the allow list by the governance account.
+- Add `transaction plt remove-from-deny-list` to remove an account from the deny list by the governance account.
 - Add `transaction plt mint` command to mint protocol level tokens by the governance account.
 - Add `transaction plt burn` command to burn protocol level tokens by the governance account.
 - Refactore plt commands into its own subcommand.

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+- Add `transaction plt add-to-allowList` to add an account to the allow list by the governance account.
+- Add `transaction plt add-to-denyList` to add an account to the deny list by the governance account.
+- Add `transaction plt remove-from-allowList` to remove an account from the allow list by the governance account.
+- Add `transaction plt remove-from-denyList` to remove an account from the deny list by the governance account.
 - Add `transaction plt mint` command to mint protocol level tokens by the governance account.
 - Add `transaction plt burn` command to burn protocol level tokens by the governance account.
 - Refactore plt commands into its own subcommand.

--- a/src/Concordium/Client/Commands.hs
+++ b/src/Concordium/Client/Commands.hs
@@ -926,7 +926,7 @@ transactionPLTAddAllowListCmd =
         "add-to-allowList"
         ( info
             ( TransactionPLTModifyList AddAllowList
-                <$> strOption (long "account" <> metavar "ACCOUNT" <> help "The account to add or remove to/from the list.")
+                <$> strOption (long "account" <> metavar "ACCOUNT" <> help "The account to add to the list.")
                 <*> strOption (long "tokenId" <> metavar "TOKEN_ID" <> help "Token id (symbol) of the token.")
                 <*> transactionOptsParser
             )
@@ -939,7 +939,7 @@ transactionPLTAddDenyListCmd =
         "add-to-denyList"
         ( info
             ( TransactionPLTModifyList AddDenyList
-                <$> strOption (long "account" <> metavar "ACCOUNT" <> help "The account to add or remove to/from the list.")
+                <$> strOption (long "account" <> metavar "ACCOUNT" <> help "The account to add to the list.")
                 <*> strOption (long "tokenId" <> metavar "TOKEN_ID" <> help "Token id (symbol) of the token.")
                 <*> transactionOptsParser
             )
@@ -952,7 +952,7 @@ transactionPLTRemoveAllowListCmd =
         "remove-from-allowList"
         ( info
             ( TransactionPLTModifyList RemoveAllowList
-                <$> strOption (long "account" <> metavar "ACCOUNT" <> help "The account to add or remove to/from the list.")
+                <$> strOption (long "account" <> metavar "ACCOUNT" <> help "The account to remove from the list.")
                 <*> strOption (long "tokenId" <> metavar "TOKEN_ID" <> help "Token id (symbol) of the token.")
                 <*> transactionOptsParser
             )
@@ -965,8 +965,8 @@ transactionPLTRemoveDenyListCmd =
         "remove-from-denyList"
         ( info
             ( TransactionPLTModifyList RemoveDenyList
-                <$> strOption (long "account" <> metavar "ACCOUNT" <> help "The account to add or remove to/from the list.")
-                <*> strOption (long "tokenId" <> metavar "TOKEN_ID" <> help "Token id (s) of the token.")
+                <$> strOption (long "account" <> metavar "ACCOUNT" <> help "The account to remove from the list.")
+                <*> strOption (long "tokenId" <> metavar "TOKEN_ID" <> help "Token id (symbol) of the token.")
                 <*> transactionOptsParser
             )
             (progDesc "Remove an account from the deny list.")

--- a/src/Concordium/Client/Commands.hs
+++ b/src/Concordium/Client/Commands.hs
@@ -923,7 +923,7 @@ transactionPLTBurnCmd =
 transactionPLTAddAllowListCmd :: Mod CommandFields PLTCmd
 transactionPLTAddAllowListCmd =
     command
-        "add-to-allowList"
+        "add-to-allow-list"
         ( info
             ( TransactionPLTModifyList AddAllowList
                 <$> strOption (long "account" <> metavar "ACCOUNT" <> help "The account to add to the list.")
@@ -936,7 +936,7 @@ transactionPLTAddAllowListCmd =
 transactionPLTAddDenyListCmd :: Mod CommandFields PLTCmd
 transactionPLTAddDenyListCmd =
     command
-        "add-to-denyList"
+        "add-to-deny-list"
         ( info
             ( TransactionPLTModifyList AddDenyList
                 <$> strOption (long "account" <> metavar "ACCOUNT" <> help "The account to add to the list.")
@@ -949,7 +949,7 @@ transactionPLTAddDenyListCmd =
 transactionPLTRemoveAllowListCmd :: Mod CommandFields PLTCmd
 transactionPLTRemoveAllowListCmd =
     command
-        "remove-from-allowList"
+        "remove-from-allow-list"
         ( info
             ( TransactionPLTModifyList RemoveAllowList
                 <$> strOption (long "account" <> metavar "ACCOUNT" <> help "The account to remove from the list.")
@@ -962,7 +962,7 @@ transactionPLTRemoveAllowListCmd =
 transactionPLTRemoveDenyListCmd :: Mod CommandFields PLTCmd
 transactionPLTRemoveDenyListCmd =
     command
-        "remove-from-denyList"
+        "remove-from-deny-list"
         ( info
             ( TransactionPLTModifyList RemoveDenyList
                 <$> strOption (long "account" <> metavar "ACCOUNT" <> help "The account to remove from the list.")

--- a/src/Concordium/Client/Commands.hs
+++ b/src/Concordium/Client/Commands.hs
@@ -15,6 +15,7 @@ module Concordium.Client.Commands (
     TransactionCmd (..),
     PLTCmd (..),
     TokenSupplyAction (..),
+    ModifyListAction (..),
     AccountCmd (..),
     ModuleCmd (..),
     ContractCmd (..),
@@ -760,10 +761,10 @@ pltCmds =
                     ( transactionPLTTransferCmd
                         <> transactionPLTMintCmd
                         <> transactionPLTBurnCmd
-                        <> transactionAddAllowListCmd
-                        <> transactionAddDenyListCmd
-                        <> transactionRemoveAllowListCmd
-                        <> transactionRemoveDenyListCmd
+                        <> transactionPLTAddAllowListCmd
+                        <> transactionPLTAddDenyListCmd
+                        <> transactionPLTRemoveAllowListCmd
+                        <> transactionPLTRemoveDenyListCmd
                     )
             )
             (progDesc "Commands for PLTs (protocol level tokens) transactions.")
@@ -898,9 +899,8 @@ transactionPLTMintCmd =
     command
         "mint"
         ( info
-            ( TransactionPLTUpdateSupply
-                <$> pure Mint
-                <*> option (eitherReader tokenAmountFromStringInform) (long "amount" <> metavar "TOKEN-AMOUNT" <> help "Amount of tokens to send.")
+            ( TransactionPLTUpdateSupply Mint
+                <$> option (eitherReader tokenAmountFromStringInform) (long "amount" <> metavar "TOKEN-AMOUNT" <> help "Amount of tokens to send.")
                 <*> strOption (long "tokenId" <> metavar "TOKEN_ID" <> help "Token id (symbol) of the token.")
                 <*> transactionOptsParser
             )
@@ -912,66 +912,61 @@ transactionPLTBurnCmd =
     command
         "burn"
         ( info
-            ( TransactionPLTUpdateSupply
-                <$> pure Burn
-                <*> option (eitherReader tokenAmountFromStringInform) (long "amount" <> metavar "TOKEN-AMOUNT" <> help "Amount of tokens to send.")
+            ( TransactionPLTUpdateSupply Burn
+                <$> option (eitherReader tokenAmountFromStringInform) (long "amount" <> metavar "TOKEN-AMOUNT" <> help "Amount of tokens to send.")
                 <*> strOption (long "tokenId" <> metavar "TOKEN_ID" <> help "Token id (symbol) of the token.")
                 <*> transactionOptsParser
             )
             (progDesc "Burn PLTs (protocol level tokens).")
         )
 
-transactionAddAllowListCmd :: Mod CommandFields PLTCmd
-transactionAddAllowListCmd =
+transactionPLTAddAllowListCmd :: Mod CommandFields PLTCmd
+transactionPLTAddAllowListCmd =
     command
         "add-to-allowList"
         ( info
-            ( TransactionPLTModifyList
-                <$> pure AddAllowList
-                <*> strOption (long "account" <> metavar "ACCOUNT" <> help "The account to add or remove to/from the list.")
-                <*> strOption (long "tokenId" <> metavar "TOKEN_ID" <> help "Token id (Symbol) of the token.")
+            ( TransactionPLTModifyList AddAllowList
+                <$> strOption (long "account" <> metavar "ACCOUNT" <> help "The account to add or remove to/from the list.")
+                <*> strOption (long "tokenId" <> metavar "TOKEN_ID" <> help "Token id (symbol) of the token.")
                 <*> transactionOptsParser
             )
             (progDesc "Add an account to the allow list.")
         )
 
-transactionAddDenyListCmd :: Mod CommandFields PLTCmd
-transactionAddDenyListCmd =
+transactionPLTAddDenyListCmd :: Mod CommandFields PLTCmd
+transactionPLTAddDenyListCmd =
     command
         "add-to-denyList"
         ( info
-            ( TransactionPLTModifyList
-                <$> pure RemoveAllowList
-                <*> strOption (long "account" <> metavar "ACCOUNT" <> help "The account to add or remove to/from the list.")
-                <*> strOption (long "tokenId" <> metavar "TOKEN_ID" <> help "Token id (Symbol) of the token.")
+            ( TransactionPLTModifyList AddDenyList
+                <$> strOption (long "account" <> metavar "ACCOUNT" <> help "The account to add or remove to/from the list.")
+                <*> strOption (long "tokenId" <> metavar "TOKEN_ID" <> help "Token id (symbol) of the token.")
                 <*> transactionOptsParser
             )
             (progDesc "Add an account to the deny list.")
         )
 
-transactionRemoveAllowListCmd :: Mod CommandFields PLTCmd
-transactionRemoveAllowListCmd =
+transactionPLTRemoveAllowListCmd :: Mod CommandFields PLTCmd
+transactionPLTRemoveAllowListCmd =
     command
         "remove-from-allowList"
         ( info
-            ( TransactionPLTModifyList
-                <$> pure AddDenyList
-                <*> strOption (long "account" <> metavar "ACCOUNT" <> help "The account to add or remove to/from the list.")
-                <*> strOption (long "tokenId" <> metavar "TOKEN_ID" <> help "Token id (Symbol) of the token.")
+            ( TransactionPLTModifyList RemoveAllowList
+                <$> strOption (long "account" <> metavar "ACCOUNT" <> help "The account to add or remove to/from the list.")
+                <*> strOption (long "tokenId" <> metavar "TOKEN_ID" <> help "Token id (symbol) of the token.")
                 <*> transactionOptsParser
             )
             (progDesc "Remove an account from the allow list.")
         )
 
-transactionRemoveDenyListCmd :: Mod CommandFields PLTCmd
-transactionRemoveDenyListCmd =
+transactionPLTRemoveDenyListCmd :: Mod CommandFields PLTCmd
+transactionPLTRemoveDenyListCmd =
     command
         "remove-from-denyList"
         ( info
-            ( TransactionPLTModifyList
-                <$> pure RemoveDenyList
-                <*> strOption (long "account" <> metavar "ACCOUNT" <> help "The account to add or remove to/from the list.")
-                <*> strOption (long "tokenId" <> metavar "TOKEN_ID" <> help "Token id (Symbol) of the token.")
+            ( TransactionPLTModifyList RemoveDenyList
+                <$> strOption (long "account" <> metavar "ACCOUNT" <> help "The account to add or remove to/from the list.")
+                <*> strOption (long "tokenId" <> metavar "TOKEN_ID" <> help "Token id (s) of the token.")
                 <*> transactionOptsParser
             )
             (progDesc "Remove an account from the deny list.")

--- a/src/Concordium/Client/Commands.hs
+++ b/src/Concordium/Client/Commands.hs
@@ -231,6 +231,9 @@ data TransactionCmd
 data TokenSupplyAction = Mint | Burn
     deriving (Show, Eq)
 
+data ModifyListAction = AddAllowList | RemoveAllowList | AddDenyList | RemoveDenyList
+    deriving (Show, Eq)
+
 data PLTCmd
     = TransactionPLTTransfer
         { tptReceiver :: !Text,
@@ -244,6 +247,12 @@ data PLTCmd
           tpusAmount :: !TokenAmount,
           tpusSymbol :: !Text,
           tpusOpts :: !(TransactionOpts (Maybe Energy))
+        }
+    | TransactionPLTModifyList
+        { tpmlAction :: !ModifyListAction,
+          tpmlAccount :: !Text,
+          tpmlSymbol :: !Text,
+          tpmlOpts :: !(TransactionOpts (Maybe Energy))
         }
     deriving (Show)
 
@@ -751,6 +760,10 @@ pltCmds =
                     ( transactionPLTTransferCmd
                         <> transactionPLTMintCmd
                         <> transactionPLTBurnCmd
+                        <> transactionAddAllowListCmd
+                        <> transactionAddDenyListCmd
+                        <> transactionRemoveAllowListCmd
+                        <> transactionRemoveDenyListCmd
                     )
             )
             (progDesc "Commands for PLTs (protocol level tokens) transactions.")
@@ -906,6 +919,62 @@ transactionPLTBurnCmd =
                 <*> transactionOptsParser
             )
             (progDesc "Burn PLTs (protocol level tokens).")
+        )
+
+transactionAddAllowListCmd :: Mod CommandFields PLTCmd
+transactionAddAllowListCmd =
+    command
+        "add-to-allowList"
+        ( info
+            ( TransactionPLTModifyList
+                <$> pure AddAllowList
+                <*> strOption (long "account" <> metavar "ACCOUNT" <> help "The account to add or remove to/from the list.")
+                <*> strOption (long "tokenId" <> metavar "TOKEN_ID" <> help "Token id (Symbol) of the token.")
+                <*> transactionOptsParser
+            )
+            (progDesc "Add an account to the allow list.")
+        )
+
+transactionAddDenyListCmd :: Mod CommandFields PLTCmd
+transactionAddDenyListCmd =
+    command
+        "add-to-denyList"
+        ( info
+            ( TransactionPLTModifyList
+                <$> pure RemoveAllowList
+                <*> strOption (long "account" <> metavar "ACCOUNT" <> help "The account to add or remove to/from the list.")
+                <*> strOption (long "tokenId" <> metavar "TOKEN_ID" <> help "Token id (Symbol) of the token.")
+                <*> transactionOptsParser
+            )
+            (progDesc "Add an account to the deny list.")
+        )
+
+transactionRemoveAllowListCmd :: Mod CommandFields PLTCmd
+transactionRemoveAllowListCmd =
+    command
+        "remove-from-allowList"
+        ( info
+            ( TransactionPLTModifyList
+                <$> pure AddDenyList
+                <*> strOption (long "account" <> metavar "ACCOUNT" <> help "The account to add or remove to/from the list.")
+                <*> strOption (long "tokenId" <> metavar "TOKEN_ID" <> help "Token id (Symbol) of the token.")
+                <*> transactionOptsParser
+            )
+            (progDesc "Remove an account from the allow list.")
+        )
+
+transactionRemoveDenyListCmd :: Mod CommandFields PLTCmd
+transactionRemoveDenyListCmd =
+    command
+        "remove-from-denyList"
+        ( info
+            ( TransactionPLTModifyList
+                <$> pure RemoveDenyList
+                <*> strOption (long "account" <> metavar "ACCOUNT" <> help "The account to add or remove to/from the list.")
+                <*> strOption (long "tokenId" <> metavar "TOKEN_ID" <> help "Token id (Symbol) of the token.")
+                <*> transactionOptsParser
+            )
+            (progDesc "Remove an account from the deny list.")
         )
 
 transactionWithScheduleCmd :: Mod CommandFields TransactionCmd

--- a/src/Concordium/Client/Runner.hs
+++ b/src/Concordium/Client/Runner.hs
@@ -996,6 +996,40 @@ handlePLTUpdateSupply backend baseCfgDir verbose tokenSupplyAction amount tokenI
         let outFile = toOutFile txOpts
         signAndProcessTransaction_ verbose txCfg encodedPayload intOpts outFile backend
 
+-- TODO
+        -- TransactionPLTModifyList account actionText listNameText symbolText txOpts -> do
+        --     baseCfg <- getBaseConfig baseCfgDir verbose
+        --     when verbose $ do
+        --         runPrinter $ printBaseConfig baseCfg
+        --         putStrLn ""
+
+        --     accountAddress <- getAccountAddressArg (bcAccountNameMap baseCfg) account
+        --     let tokenHolder = CBOR.accountTokenHolder $ naAddr accountAddress
+
+        --     withClient backend $ do
+        --         tokenGovernanceOperation <- case (actionText, listNameText) of
+        --             ("add", "allow") -> pure $ CBOR.TokenAddAllowList tokenHolder
+        --             ("remove", "allow") -> pure $ CBOR.TokenRemoveAllowList tokenHolder
+        --             ("add", "deny") -> pure $ CBOR.TokenAddDenyList tokenHolder
+        --             ("remove", "deny") -> pure $ CBOR.TokenRemoveDenyList tokenHolder
+        --             _ -> logFatal ["Only `add` or `remove` supported for the `action` option and only `allow` or `deny` supported for the `nameList` option."]
+
+        --         let tokenGovernanceTransaction = CBOR.TokenGovernanceTransaction (Seq.fromList [tokenGovernanceOperation])
+        --         let bytes = CBOR.tokenGovernanceTransactionToBytes tokenGovernanceTransaction
+        --         let tokenParameter = Types.TokenParameter $ BS.toShort bytes
+
+        --         let symbol = tokenIdFromText symbolText
+
+        --         let payload = Types.TokenGovernance symbol tokenParameter
+        --         let encodedPayload = Types.encodePayload payload
+
+        --         let nrgCost _ = return $ Just $ simpleTransferEnergyCost $ Types.payloadSize encodedPayload
+        --         txCfg <- liftIO $ getTransactionCfg baseCfg txOpts nrgCost
+
+        --         let intOpts = toInteractionOpts txOpts
+        --         let outFile = toOutFile txOpts
+        --         signAndProcessTransaction_ verbose txCfg encodedPayload intOpts outFile backend
+
 -- | Construct a transaction config for registering data.
 --   The data is read from the 'FilePath' provided.
 --   Fails if the data can't be read or it violates the size limit checked by 'Types.registeredDataFromBSS'.

--- a/src/Concordium/Client/Runner.hs
+++ b/src/Concordium/Client/Runner.hs
@@ -1023,7 +1023,7 @@ handlePLTModifyList backend baseCfgDir verbose modifyListAction account tokenIdT
             AddDenyList -> pure $ CBOR.TokenAddDenyList tokenHolder
             RemoveDenyList -> pure $ CBOR.TokenRemoveDenyList tokenHolder
 
-        let tokenGovernanceTransaction = CBOR.TokenGovernanceTransaction (Seq.fromList [tokenGovernanceOperation])
+        let tokenGovernanceTransaction = CBOR.TokenGovernanceTransaction (Seq.singleton tokenGovernanceOperation)
         let bytes = CBOR.tokenGovernanceTransactionToBytes tokenGovernanceTransaction
         let tokenParameter = Types.TokenParameter $ BS.toShort bytes
 


### PR DESCRIPTION
## Purpose

```
stack run concordium-client -- transaction plt add-to-allow-list --sender REMOTE-PLT-NODE-9 --account 3dpAB1MtU6NYyuSmcZMBt1Rev6vQtj3UDR3j2jqSVJ94fX11ge  --tokenId \$ALLOWDENY 
```
## Changes

-  Add `transaction plt add-to-allow-list`,  `transaction plt remove-from-allow-list` ,  `transaction plt add-to-deny-list`  and  `transaction plt remove-from-deny-list`  command to add/remove an account to/from the allow/deny list by the governance account.

