### PR TITLE
Use token id instead of token symbol

### DIFF
--- a/src/Concordium/Client/Commands.hs
+++ b/src/Concordium/Client/Commands.hs
@@ -1799,7 +1799,7 @@ consensusChainUpdateCmd =
                       "      \"payload\":{",
                       "         \"updateType\":\"createPLT\",",
                       "         \"update\":{",
-                      "             \"tokenSymbol\":\"EUROSTABLE\",",
+                      "             \"tokenId\":\"EUROSTABLE\",",
                       "             \"tokenModule\":\"6b7eef36dc48bb59ef9290cdbf123dad7e85efa76caf7df1ae8775735f8f59d3\",",
                       "             \"governanceAccount\":\"4FmiTW2L2AccyR9VjzsnpWFSAcohXWf7Vf797i36y526mqiEcp\",",
                       "             \"decimals\":6,",

--- a/src/Concordium/Client/GRPC2.hs
+++ b/src/Concordium/Client/GRPC2.hs
@@ -745,7 +745,7 @@ instance FromProto ProtoPLT.TokenAmount where
 instance FromProto ProtoPLT.TokenId where
     type Output ProtoPLT.TokenId = TokenId
     fromProto tokenId = do
-        let textSymbol = tokenId ^. ProtoFieldsPLT.symbol
+        let textSymbol = tokenId ^. ProtoFieldsPLT.value
         let byteString = TE.encodeUtf8 textSymbol
         let symbol = BSS.toShort byteString
         return $ TokenId symbol
@@ -1341,7 +1341,7 @@ instance FromProto Proto.RejectReason where
 instance FromProto ProtoPLT.TokenModuleRejectReason where
     type Output ProtoPLT.TokenModuleRejectReason = TokenModuleRejectReason
     fromProto reason = do
-        tmrrTokenSymbol <- fromProto $ reason ^. PLTFields.tokenSymbol
+        tmrrTokenId <- fromProto $ reason ^. PLTFields.tokenId
         let rawType = reason ^. PLTFields.type'
         let bs = TE.encodeUtf8 rawType
         let tmrrType = TokenEventType (BSS.toShort bs)
@@ -1965,7 +1965,7 @@ instance FromProto ProtoPLT.TokenModuleRef where
 instance FromProto ProtoPLT.CreatePLT where
     type Output ProtoPLT.CreatePLT = CreatePLT
     fromProto cpUpdate = do
-        _cpltTokenSymbol <- fromProto $ cpUpdate ^. PLTFields.tokenSymbol
+        _cpltTokenId <- fromProto $ cpUpdate ^. PLTFields.tokenId
         _cpltGovernanceAccount <- fromProto $ cpUpdate ^. PLTFields.governanceAccount
         _cpltDecimals <- case toIntegralSized (cpUpdate ^. PLTFields.decimals) of
             Nothing -> fromProtoFail "CreatePLT: decimals out of range"

--- a/src/Concordium/Client/Output.hs
+++ b/src/Concordium/Client/Output.hs
@@ -912,7 +912,7 @@ showEvent verbose ciM = \case
             invalidCBOR =
                 printf
                     "Could not decode token event details of token module event with token id %s and type %s as valid CBOR. The hex value of the event details is %s."
-                    (show $ Types._teSymbol tokenEvent)
+                    (show $ Types._teTokenId tokenEvent)
                     (show $ Types._teType tokenEvent)
                     (show bss)
             bsl = BSL.fromStrict $ BSS.fromShort bss
@@ -925,7 +925,7 @@ showEvent verbose ciM = \case
         in  Just $
                 printf
                     "Token module event of token id %s and type %s occured with event details: \n%s"
-                    (show $ Types._teSymbol tokenEvent)
+                    (show $ Types._teTokenId tokenEvent)
                     (show $ Types._teType tokenEvent)
                     eventDetailsJSON
   where
@@ -1123,13 +1123,13 @@ showRejectReason verbose = \case
             Nothing ->
                 printf
                     "%s token-holder transaction was rejected due to: %s"
-                    (show $ Types.tmrrTokenSymbol reason)
+                    (show $ Types.tmrrTokenId reason)
                     (show $ Types.tmrrType reason)
             Just detail -> do
                 let invalidCBOR =
                         printf
                             "%s token-holder transaction was rejected due to: %s\n   details (undecoded CBOR): %s"
-                            (show $ Types.tmrrTokenSymbol reason)
+                            (show $ Types.tmrrTokenId reason)
                             (show $ Types.tmrrType reason)
                             (show detail)
                 let detailsShortByteString = Types.tokenEventDetailsBytes detail
@@ -1141,7 +1141,7 @@ showRejectReason verbose = \case
                             then
                                 printf
                                     "%s token-holder transaction was rejected due to: %s\n   details (undecoded CBOR): %s\n   details (decoded CBOR):"
-                                    (show $ Types.tmrrTokenSymbol reason)
+                                    (show $ Types.tmrrTokenId reason)
                                     (show $ Types.tmrrType reason)
                                     (show details)
                                     (showPrettyJSON x)
@@ -1152,13 +1152,13 @@ showRejectReason verbose = \case
             Nothing ->
                 printf
                     "%s token-governance transaction was rejected due to: %s"
-                    (show $ Types.tmrrTokenSymbol reason)
+                    (show $ Types.tmrrTokenId reason)
                     (show $ Types.tmrrType reason)
             Just detail -> do
                 let invalidCBOR =
                         printf
                             "%s token-governance transaction was rejected due to: %s\n   details (undecoded CBOR): %s"
-                            (show $ Types.tmrrTokenSymbol reason)
+                            (show $ Types.tmrrTokenId reason)
                             (show $ Types.tmrrType reason)
                             (show detail)
                 let detailsShortByteString = Types.tokenEventDetailsBytes detail
@@ -1170,7 +1170,7 @@ showRejectReason verbose = \case
                             then
                                 printf
                                     "%s token-governance transaction was rejected due to: %s\n   details (undecoded CBOR): %s\n   details (decoded CBOR):"
-                                    (show $ Types.tmrrTokenSymbol reason)
+                                    (show $ Types.tmrrTokenId reason)
                                     (show $ Types.tmrrType reason)
                                     (show details)
                                     (showPrettyJSON x)

--- a/src/Concordium/Client/Utils.hs
+++ b/src/Concordium/Client/Utils.hs
@@ -93,7 +93,7 @@ tokenIdFromText s =
     let encoded = Text.encodeUtf8 s
     in  if BS.length encoded <= 255
             then Right $ TokenId $ SBS.toShort encoded
-            else Left "Token symbol must be at most 255 bytes when UTF-8 encoded."
+            else Left "Token Id must be at most 255 bytes when UTF-8 encoded."
 
 amountFractionFromStringInform :: String -> Either String AmountFraction
 amountFractionFromStringInform s =


### PR DESCRIPTION
## Purpose

Consistently use token ID
