### PR TITLE
Fix displaying the decoded CBOR in PLT reject reasons

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+- Fix a bug in displaying the decoded CBOR from rejected PLT transactions.
+
+
 ## 9.1.0 - 2025-05-20
 
 - Add `transaction plt add-to-allow-list` to add an account to the allow list by the governance account.

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -4,7 +4,6 @@
 
 - Fix a bug in displaying the decoded CBOR from rejected PLT transactions.
 
-
 ## 9.1.0 - 2025-05-20
 
 - Add `transaction plt add-to-allow-list` to add an account to the allow list by the governance account.

--- a/src/Concordium/Client/Output.hs
+++ b/src/Concordium/Client/Output.hs
@@ -1140,7 +1140,7 @@ showRejectReason verbose = \case
                         if rest == BSL.empty
                             then
                                 printf
-                                    "%s token-holder transaction was rejected due to: %s\n   details (undecoded CBOR): %s\n   details (decoded CBOR):"
+                                    "%s token-holder transaction was rejected due to: %s\n   details (undecoded CBOR): %s\n   details (decoded CBOR): %s"
                                     (show $ Types.tmrrTokenId reason)
                                     (show $ Types.tmrrType reason)
                                     (show details)
@@ -1169,7 +1169,7 @@ showRejectReason verbose = \case
                         if rest == BSL.empty
                             then
                                 printf
-                                    "%s token-governance transaction was rejected due to: %s\n   details (undecoded CBOR): %s\n   details (decoded CBOR):"
+                                    "%s token-governance transaction was rejected due to: %s\n   details (undecoded CBOR): %s\n   details (decoded CBOR): %s"
                                     (show $ Types.tmrrTokenId reason)
                                     (show $ Types.tmrrType reason)
                                     (show details)


### PR DESCRIPTION
## Purpose

Fix displaying the decoded CBOR in PLT reject reasons. This is caused by a bug where the format string has an incorrect number of arguments.

## Changes

- Fix the format strings.

## Checklist

- [X] My code follows the style of this project.
- [X] The code compiles without warnings.
- [X] I have performed a self-review of the changes.
- [X] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [X] (If necessary) I have updated the CHANGELOG.
