### PR TITLE
Propagate module state json representation from base

### DIFF
--- a/src/Concordium/Client/GRPC2.hs
+++ b/src/Concordium/Client/GRPC2.hs
@@ -3764,13 +3764,17 @@ getPrePreCooldownAccounts bhInput =
     msg = toProto bhInput
 
 -- | Get the info of a protocol level token after a given block.
-getTokenInfo :: (MonadIO m) => Text -> BlockHashInput -> ClientMonad m (GRPCResult (FromProtoResult Tokens.TokenInfo))
-getTokenInfo tokenIdText bhInput = do
+getTokenInfo :: (MonadIO m) => TokenId -> BlockHashInput -> ClientMonad m (GRPCResult (FromProtoResult Tokens.TokenInfo))
+getTokenInfo tokenId bhInput = do
+    let msg = defMessage & ProtoFields.blockHash .~ toProto bhInput & ProtoFields.tokenId .~ toProto tokenId
+    withUnary (call @"getTokenInfo") msg (fmap fromProto)
+
+getTokenInfoFromText :: (MonadIO m) => Text -> BlockHashInput -> ClientMonad m (GRPCResult (FromProtoResult Tokens.TokenInfo))
+getTokenInfoFromText tokenIdText bhInput = do
     tokenId <- case tokenIdFromText tokenIdText of
         Right val -> return val
         Left err -> logFatal ["Error couldn't parse token id:", err]
-    let msg = defMessage & ProtoFields.blockHash .~ toProto bhInput & ProtoFields.tokenId .~ toProto tokenId
-    withUnary (call @"getTokenInfo") msg (fmap fromProto)
+    getTokenInfo tokenId bhInput
 
 -- | Get information related to the baker election for a particular block.
 getElectionInfo :: (MonadIO m) => BlockHashInput -> ClientMonad m (GRPCResult (FromProtoResult BlockBirkParameters))

--- a/src/Concordium/Client/Runner.hs
+++ b/src/Concordium/Client/Runner.hs
@@ -4494,7 +4494,7 @@ processLegacyCmd action backend =
         GetTokenInfo tokenId block -> do
             b <- readBlockHashOrDefault Best block
             withClient backend $
-                getTokenInfo tokenId b
+                getTokenInfoFromText tokenId b
                     >>= printResponseValueAsJSON
         GetScheduledReleaseAccounts block ->
             withClient backend $


### PR DESCRIPTION
## Purpose

## Changes

- Propagate changes from base: `Module state` has a JSON representation now: (https://github.com/Concordium/concordium-base/pull/665).
- Add functions `getTokenInfo` and `getTokenInfoFromText` (used in https://github.com/Concordium/concordium-wallet-proxy/pull/130)
