### PR TITLE
Handle renormalizing amounts to the correct number of decimals.

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+- The number of decimals in PLT amounts for the `plt` `send`, `mint` and `burn` operations is checked and adjusted if necessary.
+  This allows specifying 10 instead of 10.000000 for a PLT with 6 decimal places, for instance.
+
 ## 9.1.2-alpha (Compatible with node version 9.0.5) - 2025-06-30
 
 - Compatibility with node version 9.0.5:


### PR DESCRIPTION
## Purpose

Closes [COR-1457](https://linear.app/concordium/issue/COR-1457/concordium-client-handle-plt-amounts)

Convert PLT amounts to the correct number of decimals, querying the node.

## Changes

- Add 'renormalizeTokenAmount' helper function
- Query the token info and renormalize token amounts in plt transfer, mint and burn operations.

## Checklist

- [X] My code follows the style of this project.
- [X] The code compiles without warnings.
- [X] I have performed a self-review of the changes.
- [X] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [X] (If necessary) I have updated the CHANGELOG.
