### PR TITLE
Update GHC to 9.10.2 (LTS 24.0)

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -36,7 +36,7 @@ on:
 
 env:
   RUST: 1.82
-  GHC: 9.6.6
+  GHC: 9.8.4
 
 jobs:
   fourmolu:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -47,9 +47,9 @@ jobs:
     - name: Download fourmolu
       uses: supplypike/setup-bin@v1
       with:
-        uri: 'https://github.com/fourmolu/fourmolu/releases/download/v0.13.1.0/fourmolu-0.13.1.0-linux-x86_64'
+        uri: 'https://github.com/fourmolu/fourmolu/releases/download/v0.18.0.0/fourmolu-0.18.0.0-linux-x86_64'
         name: 'fourmolu'
-        version: '0.13.1.0'
+        version: '0.18.0.0'
 
     - name: Checkout project
       uses: actions/checkout@v2

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -18,8 +18,8 @@ on:
     - '*.*.*-*-*'
 
 env:
-  STACK_VERSION: '3.1.1'
-  GHC_VERSION: '9.8.4'
+  STACK_VERSION: '3.7.1'
+  GHC_VERSION: '9.10.2'
   RUST_VERSION: '1.82'
   SERVICE: "${{ inputs.service }}"
   PROTOC_VERSION: '28.3'

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -19,7 +19,7 @@ on:
 
 env:
   STACK_VERSION: '3.1.1'
-  GHC_VERSION: '9.6.6'
+  GHC_VERSION: '9.8.4'
   RUST_VERSION: '1.82'
   SERVICE: "${{ inputs.service }}"
   PROTOC_VERSION: '28.3'

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Bump GHC version to 9.8.4 (lts-23.27).
+
 ## 9.1.3-alpha (Compatible with node version 9.0.6) - 2025-07-14
 
 - The number of decimals in PLT amounts for the `plt` `send`, `mint` and `burn` operations is checked and adjusted if necessary.

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -2,7 +2,7 @@
 
 ## Unreleased
 
-- Bump GHC version to 9.8.4 (lts-23.27).
+- Bump GHC version to 9.10.2 (lts-24.0).
 
 ## 9.1.3-alpha (Compatible with node version 9.0.6) - 2025-07-14
 

--- a/src/Concordium/Client/Commands.hs
+++ b/src/Concordium/Client/Commands.hs
@@ -807,8 +807,7 @@ transactionAddSignatureCmd =
                 <$> strArgument (metavar "FILE" <> help "File containing a signed transaction in JSON format.")
                 <*> optional
                     ( strOption
-                        ( long "signers" <> metavar "SIGNERS" <> help "Specification of which (local) keys to sign with. Example: \"0:1,0:2,3:0,3:1\" specifies that credential holder 0 signs with keys 1 and 2, while credential holder 3 signs with keys 0 and 1"
-                        )
+                        (long "signers" <> metavar "SIGNERS" <> help "Specification of which (local) keys to sign with. Example: \"0:1,0:2,3:0,3:1\" specifies that credential holder 0 signs with keys 1 and 2, while credential holder 3 signs with keys 0 and 1")
                     )
                 <*> optional
                     (strOption (long "keys" <> metavar "KEYS" <> help "Any number of sign/verify keys specified in a JSON file."))

--- a/src/Concordium/Client/Config.hs
+++ b/src/Concordium/Client/Config.hs
@@ -29,7 +29,7 @@ import Concordium.Common.Version
 import Data.Aeson ((.:), (.=))
 
 import Data.Char
-import Data.List (find, foldl', sortOn)
+import Data.List (find, sortOn)
 import Data.List.Split
 import qualified Data.Map.Strict as M
 import Data.String (IsString)
@@ -215,7 +215,6 @@ initBaseConfig f verbose = do
     if baseCfgDirExists
         then when verbose $ logInfo [[i|skipping '#{baseCfgDir}': directory already exists|]]
         else -- Only explicitly handle a permission error since that is likely the most common one.
-
             handleJust
                 (guard . isPermissionError)
                 (\_ -> logFatal ["cannot create directory, permission denied"])

--- a/src/Concordium/Client/Output.hs
+++ b/src/Concordium/Client/Output.hs
@@ -58,7 +58,7 @@ import qualified Data.ByteString.Lazy as BSL
 import qualified Data.ByteString.Short as BSS
 import Data.Either (isRight)
 import Data.Functor
-import Data.List (elemIndex, foldl', intercalate, nub, partition, sortOn)
+import Data.List (elemIndex, intercalate, nub, partition, sortOn)
 import qualified Data.Map.Strict as Map
 import Data.Maybe
 import Data.Ratio

--- a/stack.yaml
+++ b/stack.yaml
@@ -17,7 +17,7 @@
 #
 # resolver: ./custom-snapshot.yaml
 # resolver: https://example.com/snapshots/2018-01-01.yaml
-resolver: lts-22.39
+resolver: lts-23.27
 
 # User packages to be built.
 # Various formats can be used as shown in the example below.
@@ -42,6 +42,9 @@ packages:
 # (e.g., acme-missiles-0.3)
 
 extra-deps:
+- network-control-0.0.2
+- http2-5.0.1
+- tls-1.8.0
 # http2-client was never included in stackage
 - github: Concordium/http2-client
   commit: af0edc5fba5265ba9a4b2f91cfc3c466e4c82197
@@ -53,13 +56,19 @@ extra-deps:
     - http2-grpc-proto-lens
     - http2-grpc-types
 
-- proto-lens-setup-0.4.0.7@sha256:acca0b04e033ea0a017f809d91a7dbc942e025ec6bc275fa21647352722c74cc,3122
-- proto-lens-protoc-0.8.0.0@sha256:a146ee8c9af9e445ab05651e688deb0ff849357d320657d6cea5be33cb54b960,2235
-- ghc-source-gen-0.4.4.0@sha256:8499f23c5989c295f3b002ad92784ca5fed5260fd4891dc816f17d30c5ba9cd9,4236
-# Cabal-3.10.3.0 (from the lts-22.39 snapshot) breaks linking on Windows, but this should be
-# fixed in newer versions.  This should be removed once we update to an lts that uses a new
-# enough version of Cabal.
-- Cabal-3.10.1.0
+# lts-23.27 uses Cabal-3.10.3.0, which includes a fix (https://github.com/haskell/cabal/pull/9554)
+# that unfortunately breaks linking on Windows by adding -rpath linker flags. It appears this
+# is fixed as of Cabal-3.12.1.0 (and maybe 3.12.0.0), and this seems to be compatible with our
+# other dependencies, so we use it. Once we update to an lts that uses a new enough version of
+# Cabal, we should remove this dependency (which shadows the one from the snapshot).
+- Cabal-3.12.1.0
+- Cabal-syntax-3.12.1.0
+
+# We allow newer versions of dependencies because we use
+# old versions of http2-client and http2-grpc-haskell, which
+# have not been updated.
+allow-newer: true
+
 
 # Override default flag values for local packages and extra-deps
 # flags: {}

--- a/stack.yaml
+++ b/stack.yaml
@@ -17,7 +17,7 @@
 #
 # resolver: ./custom-snapshot.yaml
 # resolver: https://example.com/snapshots/2018-01-01.yaml
-resolver: lts-23.27
+resolver: lts-24.0
 
 # User packages to be built.
 # Various formats can be used as shown in the example below.
@@ -55,14 +55,6 @@ extra-deps:
     - http2-client-grpc
     - http2-grpc-proto-lens
     - http2-grpc-types
-
-# lts-23.27 uses Cabal-3.10.3.0, which includes a fix (https://github.com/haskell/cabal/pull/9554)
-# that unfortunately breaks linking on Windows by adding -rpath linker flags. It appears this
-# is fixed as of Cabal-3.12.1.0 (and maybe 3.12.0.0), and this seems to be compatible with our
-# other dependencies, so we use it. Once we update to an lts that uses a new enough version of
-# Cabal, we should remove this dependency (which shadows the one from the snapshot).
-- Cabal-3.12.1.0
-- Cabal-syntax-3.12.1.0
 
 # We allow newer versions of dependencies because we use
 # old versions of http2-client and http2-grpc-haskell, which


### PR DESCRIPTION
## Purpose

Part of [COR-1558](https://linear.app/concordium/issue/COR-1558/upgrade-haskell-ghc-to-=-967)

Update to LTS 24.0, GHC 9.10.2

## Changes

- Bump the LTS version
- Bump the GHC version
- Bump the stack version to 3.7.1
- Bump the fourmolu version to 0.18.0.0
- Remove some pinned dependencies that are now available in the LTS snapshot
- Pin older versions of http2, network-control and tls as the http2-client-grpc related dependencies don't work with them.
- `allow-newer` versions of Haskell packages, to avoid having to update the forked libraries just to widen the version constraints.
- Minor fixes

## Checklist

- [X] My code follows the style of this project.
- [X] The code compiles without warnings.
- [X] I have performed a self-review of the changes.
- [X] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [X] (If necessary) I have updated the CHANGELOG.
