### PR TITLE
fix: fix broken link to docs website

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,7 +1,7 @@
 name: Build and test
 
 # Builds dependencies
-# Builds and tests concordium client
+# Builds and tests Concordium Client
 
 on:
   pull_request:

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ The tool has commands to
 - inspect and manage the node.
 
 For more information, please [read our
-documentation](https://developer.concordium.software/en/mainnet/net/references/concordium-client.html).
+documentation](https://docs.concordium.com/en/mainnet/tools/concordium-client.html).
 
 [Binary distributions are available for Linux, macOS, and
 Windows](https://developer.concordium.software/en/mainnet/net/installation/downloads.html#concordium-client).

--- a/Setup.hs
+++ b/Setup.hs
@@ -24,3 +24,4 @@ main =
         simpleUserHooks
             { confHook = autoConfHook
             }
+

--- a/Setup.hs
+++ b/Setup.hs
@@ -24,4 +24,3 @@ main =
         simpleUserHooks
             { confHook = autoConfHook
             }
-


### PR DESCRIPTION
## Purpose

This URL is broken: https://docs.concordium.com/en/mainnet/docs/network/concordium-client.html 

New one seems to be: https://docs.concordium.com/en/mainnet/tools/concordium-client.html

## Changes

Readme only.

## Checklist

- [-] My code follows the style of this project.
- [-] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [-] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [-] (If necessary) I have updated the CHANGELOG.
